### PR TITLE
testcase.h uses the Solver data type, include it.

### DIFF
--- a/ext/testcase.h
+++ b/ext/testcase.h
@@ -7,6 +7,7 @@
 
 #include "pool.h"
 #include "repo.h"
+#include "solver.h"
 
 #define TESTCASE_RESULT_TRANSACTION	(1 << 0)
 #define TESTCASE_RESULT_PROBLEMS	(1 << 1)


### PR DESCRIPTION
prevents compilation if the client doens't #inlcude solver otherwise.

Hi Michael,

I started working on some unit tests and hit the problem above^.

I wanted to ask: if I need some extension to the testing susetags format (e.g. give packages from @System a rpmdbid, something that really doesnt make a lot of sense outside the tests), can I just go ahead and add them to testcase_add_susetags() ? What would be the best way, new 'case's or maybe a callback parameter that would call back into my code for unrecognized tags? (maybe Im thinking too much ahead now..).

Thank you,
Ales
