### PR TITLE
bitmap: implement map_and_not.

### DIFF
--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -71,4 +71,16 @@ map_and(Map *t, Map *s)
 	*ti++ &= *si++;
 }
 
+/* like map_and but negates value in s first, i.e. t & ~s */
+void
+map_and_not(Map *t, Map *s)
+{
+    unsigned char *ti, *si, *end;
+    ti = t->map;
+    si = s->map;
+    end = ti + t->size;
+    while (ti < end)
+	*ti++ &= ~*si++;
+}
+
 /* EOF */

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -35,6 +35,7 @@ extern void map_init_clone(Map *t, Map *s);
 extern void map_grow(Map *m, int n);
 extern void map_free(Map *m);
 extern void map_and(Map *t, Map *s);
+extern void map_and_not(Map *t, Map *s);
 
 static inline void map_empty(Map *m)
 {

--- a/src/libsolv.ver
+++ b/src/libsolv.ver
@@ -27,6 +27,7 @@ SOLV_1.0 {
 		dirpool_init;
 		dirpool_make_dirtraverse;
 		map_and;
+		map_and_not;
 		map_free;
 		map_grow;
 		map_init;


### PR DESCRIPTION
Hi Michael,

here's yet another bitmap.h operator I use when negating a query filter. If you think there should instead be map_not and then map_and let me know (I did map_and_not() because I only have to walk the bitmap once then).

Thanks,
Ales
