### PR TITLE
- repo_rpmdb: read in RPMTAG_SHA1HEADER

### DIFF
--- a/ext/repo_rpmdb.c
+++ b/ext/repo_rpmdb.c
@@ -51,6 +51,8 @@
 /* 4: fixed triggers */
 #define RPMDB_COOKIE_VERSION 4
 
+#define	TAG_SIGBASE		256
+#define TAG_SHA1HEADER		TAG_SIGBASE+13
 #define TAG_NAME		1000
 #define TAG_VERSION		1001
 #define TAG_RELEASE		1002
@@ -983,6 +985,12 @@ rpm2solv(Pool *pool, Repo *repo, Repodata *data, Solvable *s, RpmHead *rpmhead, 
       str = headstring(rpmhead, TAG_PACKAGER);
       if (str)
 	repodata_set_poolstr(data, handle, SOLVABLE_PACKAGER, str);
+      if ((flags & RPM_ADD_WITH_HDRID) != 0)
+	{
+	  str = headstring(rpmhead, TAG_SHA1HEADER);
+	  if (str)
+	    repodata_set_poolstr(data, handle, SOLVABLE_HDRID, str);
+	}
       u32 = headint32(rpmhead, TAG_BUILDTIME);
       if (u32)
         repodata_set_num(data, handle, SOLVABLE_BUILDTIME, u32);

--- a/ext/repo_rpmdb.h
+++ b/ext/repo_rpmdb.h
@@ -22,6 +22,7 @@ extern Id repo_add_pubkey(Repo *repo, const char *key, int flags);
 #define RPM_ADD_WITH_SHA1SUM	(1 << 12)
 #define RPM_ADD_WITH_SHA256SUM	(1 << 13)
 #define RPM_ADD_TRIGGERS	(1 << 14)
+#define RPM_ADD_WITH_HDRID	(1 << 15)
 
 #define RPM_ITERATE_FILELIST_ONLYDIRS	(1 << 0)
 #define RPM_ITERATE_FILELIST_WITHMD5	(1 << 1)


### PR DESCRIPTION
Hi Michael,

what do you think about adding the SHA1_HEADER to the solvable?

The reason why I'm doing this is the current yum's history feature depends on it as a "unique" identification of an installed package (and who knows what else).

Ales
