### PR TITLE
cosmetic: fix possibly uninitialized variable warning in solv.c.

### DIFF
--- a/examples/solv.c
+++ b/examples/solv.c
@@ -1299,7 +1299,7 @@ repomd_load_ext(Repo *repo, Repodata *data)
   struct repoinfo *cinfo;
   const unsigned char *filechksum;
   Id filechksumtype;
-  int r;
+  int r = 0;
 
   cinfo = repo->appdata;
   repomdtype = repodata_lookup_str(data, SOLVID_META, REPOSITORY_REPOMD_TYPE);


### PR DESCRIPTION
Hello, this is a cosmetic thing fixing a gcc warning (variable might be uninitialized) that appears during the package's build in Fedora.
