### PR TITLE
Fix misuses of memset

### DIFF
--- a/examples/solv.c
+++ b/examples/solv.c
@@ -1706,16 +1706,16 @@ read_repos(Pool *pool, struct repoinfo *repoinfos, int nrepoinfos)
 #if defined(ENABLE_RPMDB) && (defined(SUSE) || defined(FEDORA))
   printf("rpm database:");
   if (stat(pool_prepend_rootdir_tmp(pool, "/var/lib/rpm/Packages"), &stb))
-    memset(&stb, 0, sizeof(&stb));
+    memset(&stb, 0, sizeof(stb));
 #endif
 #if defined(ENABLE_DEBIAN) && defined(DEBIAN)
   printf("dpgk database:");
   if (stat(pool_prepend_rootdir_tmp(pool, "/var/lib/dpkg/status"), &stb))
-    memset(&stb, 0, sizeof(&stb));
+    memset(&stb, 0, sizeof(stb));
 #endif
 #ifdef NOSYSTEM
   printf("no installed database:");
-  memset(&stb, 0, sizeof(&stb));
+  memset(&stb, 0, sizeof(stb));
 #endif
   calc_checksum_stat(&stb, REPOKEY_TYPE_SHA256, 0, installedcookie);
   if (usecachedrepo(repo, 0, installedcookie, 0))

--- a/src/md5.c
+++ b/src/md5.c
@@ -266,5 +266,5 @@ void solv_MD5_Final(unsigned char *result, MD5_CTX *ctx)
 	result[14] = ctx->d >> 16;
 	result[15] = ctx->d >> 24;
 
-	memset(ctx, 0, sizeof(ctx));
+	memset(ctx, 0, sizeof(*ctx));
 }


### PR DESCRIPTION
src/md5.c: In function 'sat_MD5_Final':
src/md5.c:269:23: error: argument to 'sizeof' in 'memset' call is the same expression as the destination; did you mean to dereference it? [-Werror=sizeof-pointer-memaccess]
  memset(ctx, 0, sizeof(ctx));
                       ^
examples/solv.c: In function 'read_repos':
examples/solv.c:1616:27: error: argument to 'sizeof' in 'memset' call is the same expression as the destination; did you mean to remove the addressof? [-Werror=sizeof-pointer-memaccess]
     memset(&stb, 0, sizeof(&stb));
                           ^
