### PR TITLE
primary.xml: Parse/store the baseurl attribute

### DIFF
--- a/ext/repo_rpmmd.c
+++ b/ext/repo_rpmmd.c
@@ -765,7 +765,12 @@ startElement(void *userData, const char *name, const char **atts)
     case STATE_LOCATION:
       str = find_attr("href", atts);
       if (str)
-	repodata_set_location(pd->data, handle, 0, 0, str);
+	{
+	  repodata_set_location(pd->data, handle, 0, 0, str);
+	  str = find_attr("xml:base", atts);
+	  if (str)
+	    repodata_set_poolstr(pd->data, handle, SOLVABLE_MEDIABASE, str);
+	}
       break;
     case STATE_CHECKSUM:
       str = find_attr("type", atts);

--- a/src/knownid.h
+++ b/src/knownid.h
@@ -247,6 +247,7 @@ KNOWNID(PUBKEY_KEYID,		        "pubkey:keyid"),
 KNOWNID(PUBKEY_FINGERPRINT,	        "pubkey:fingerprint"),
 KNOWNID(PUBKEY_EXPIRES,		        "pubkey:expires"),
 KNOWNID(PUBKEY_SIGNATURES,	        "pubkey:signatures"),
+KNOWNID(SOLVABLE_MEDIABASE,		"solvable:mediabase"), /* <location xml:base=... > */
 
 KNOWNID(ID_NUM_INTERNAL,		0)
 


### PR DESCRIPTION
When createrepo is run with --baseurl=BASEURL, the specified BASEURL is stored in primary.xml.  It's a (single-valued) override to the default set of mirrors.  Release engineers often maintain smaller repositories that use distinct baseurls, and merge their metadata.

libsolv currently drops the baseurl attribute, so client uses the default baseurls, and 404s.
See https://bugzilla.redhat.com/show_bug.cgi?id=968159

Most packages usually don't specify baseurl, and the baseurl domain is small, so poolstr seems to fit this.
