### PR TITLE
Add ppc64p7 architecture

### DIFF
--- a/src/poolarch.c
+++ b/src/poolarch.c
@@ -29,6 +29,7 @@ static const char *archpolicies[] = {
   "s390x",	"s390x:s390",
   "s390",	"s390",
   "ia64",	"ia64:i686:i586:i486:i386",
+  "ppc64p7",	"ppc64p7",
   "ppc64",	"ppc64:ppc",
   "ppc",	"ppc",
   "aarch64",   "aarch64",


### PR DESCRIPTION
This commit adds ppc64p7 architecture. Which is just ppc64 but POWER7
optimized
