### PR TITLE
repo_rpmdb's freestate() can free rootdir only after closedbenv() finish...

### DIFF
--- a/ext/repo_rpmdb.c
+++ b/ext/repo_rpmdb.c
@@ -1414,12 +1414,12 @@ freestate(struct rpmdbstate *state)
   /* close down */
   if (!state)
     return;
-  if (state->rootdir)
-    solv_free(state->rootdir);
   if (state->db)
     state->db->close(state->db, 0);
   if (state->dbenv)
     closedbenv(state);
+  if (state->rootdir)
+    solv_free(state->rootdir);
   solv_free(state->rpmhead);
 }
 


### PR DESCRIPTION
...es.

Because serialize_dbenv_ops() still uses rootdir.
