### PR TITLE
Save "Status" field of debian packages during parsing of packages list.

### DIFF
--- a/ext/repo_deb.c
+++ b/ext/repo_deb.c
@@ -313,6 +313,10 @@ control2solvable(Solvable *s, Repodata *data, char *control)
 	      havesource = 1;
 	    }
 	  break;
+	case 'S' << 8 | 'T':
+	  if (!strcasecmp(tag, "status"))
+	    repodata_set_str(data, s - pool->solvables, DEB_DEBSTATUS, q);
+	  break;
 	case 'S' << 8 | 'U':
 	  if (!strcasecmp(tag, "suggests"))
 	    s->suggests = makedeps(repo, q, s->suggests, 0);

--- a/src/knownid.h
+++ b/src/knownid.h
@@ -45,6 +45,7 @@ KNOWNID(SOLVABLE_SUGGESTS,		"solvable:suggests"),
 KNOWNID(SOLVABLE_SUPPLEMENTS,		"solvable:supplements"),
 KNOWNID(SOLVABLE_ENHANCES,		"solvable:enhances"),
 KNOWNID(RPM_RPMDBID,			"rpm:dbid"),
+KNOWNID(DEB_DEBSTATUS,			"deb:status"),
 
 /* normal requires before this, prereqs after this */
 KNOWNID(SOLVABLE_PREREQMARKER,		"solvable:prereqmarker"),


### PR DESCRIPTION
When populating packages from "/var/lib/dpkg/status" into repo that should be marked as "installed repo",
there should be possible to filter partially installed packages based on their "Status" field.
This commit makes saving this field for later manual filtering.