### PR TITLE
Ship patcheck and avoid false positive errors with src rpms

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -91,6 +91,8 @@ TARGET_LINK_LIBRARIES (installcheck libsolvext libsolv ${SYSTEM_LIBRARIES})
 IF (SUSE)
 ADD_EXECUTABLE (patchcheck patchcheck.c)
 TARGET_LINK_LIBRARIES (patchcheck libsolvext libsolv ${SYSTEM_LIBRARIES})
+
+SET (tools_list ${tools_list} patchcheck)
 ENDIF (SUSE)
 
 IF (ENABLE_APPDATA)

--- a/tools/patchcheck.c
+++ b/tools/patchcheck.c
@@ -158,6 +158,9 @@ toinst(Solver *solv, Repo *repo, Repo *instrepo)
       if (p < 0 || p == SYSTEMSOLVABLE)
 	continue;
 
+      Solvable *s = pool->solvables + p;
+      if (s->arch == ARCH_SRC || s->arch == ARCH_NOSRC)
+        continue;
      /* printf(" toinstall %s\n", pool_solvid2str(pool, p));*/
       /* oh my! */
       pool->solvables[p].repo = instrepo;


### PR DESCRIPTION
Newer patch files include conflicts on src/nosrc packages. Example:

$ zypper info -t patch  SUSE-SLE-WE-12-2015-59
(...)
Provides:
  patch:SUSE-SLE-WE-12-2015-59 == 1
Conflicts:
  srcpackage:libvirt < 1.2.5-21.1
  libvirt-client-32bit.x86_64 < 1.2.5-21.1

In practice though, such conflicts can never prevent the installation of a patch, as installed src/nosrc packages are not recorded in the RPM database.

This fix makes patchcheck filter out src/nosrc RPMs from its "to install" repository, preventing it
finding lots of conflicts that won't happen in the real world.