### PR TITLE
Extend support for MIPS architectures

### DIFF
--- a/src/poolarch.c
+++ b/src/poolarch.c
@@ -59,7 +59,10 @@ static const char *archpolicies[] = {
   "sparcv9",	"sparcv9:sparcv8:sparc",
   "sparcv8",	"sparcv8:sparc",
   "sparc",	"sparc",
+  "mips",	"mips",
   "mipsel",	"mipsel",
+  "mips64",	"mips64",
+  "mips64el",	"mips64el",
   "m68k",	"m68k",
 #ifdef FEDORA
   "ia32e",	"ia32e:x86_64:athlon:i686:i586:i486:i386",


### PR DESCRIPTION
Signed-off-by: Michal Toman <mtoman@fedoraproject.org>

Add support for mips, mips64 and mips64el architectures