### PR TITLE
python: drop wrong set of PythonInterp_FIND_VERSION

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,7 +1,4 @@
-#SET (PythonLibs_FIND_VERSION 3)
-
 FIND_PACKAGE (PythonLibs)
-SET (PythonInterp_FIND_VERSION ${PYTHONLIBS_VERSION_STRING})
 FIND_PACKAGE (PythonInterp REQUIRED)
 EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib(True))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
 


### PR DESCRIPTION
Now upstream CMake taking care about consistent versions between
libs and interpreter.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>