### PR TITLE
application: Don't use an appdata() requires if the package name is k…

### DIFF
--- a/src/linkedpkg.c
+++ b/src/linkedpkg.c
@@ -63,7 +63,7 @@ find_application_link(Pool *pool, Solvable *s, Id *reqidp, Queue *qr, Id *prvidp
 	  else
 	    pkgname = req;
 	}
-      req = appdataid;
+      req = pkgname ? pkgname : appdataid;
     }
   if (!req)
     return;
@@ -77,7 +77,7 @@ find_application_link(Pool *pool, Solvable *s, Id *reqidp, Queue *qr, Id *prvidp
 	    continue;
 	  if (strncmp("application-appdata(", pool_id2str(pool, prv), 20))
 	    continue;
-	  if (!strcmp(pool_id2str(pool, prv) + 12, pool_id2str(pool, req)))
+	  if (pkgname || !strcmp(pool_id2str(pool, prv) + 12, pool_id2str(pool, req)))
 	    break;
 	}
     }


### PR DESCRIPTION
…nown

The need for guessing the `appdata(SOME_UNIQ_STRING)` provides, which may or may not have been inserted into a package providing application data, could be avoided by using the <pkgname> hint, if provided by the application metadata.

Todo: For installed application one could lookup the package that installed the appdata.xml rather than guessing it's provides. With this, extra appdata-provides in packages  could be superfluous.