### PR TITLE
Support getting headers from rpmdb via librpm

### DIFF
--- a/ext/repo_rpmdb.c
+++ b/ext/repo_rpmdb.c
@@ -1548,7 +1548,9 @@ freestate(struct rpmdbstate *state)
   /* close down */
   if (!state)
     return;
-#ifndef ENABLE_RPMDB_BYRPMHEADER
+#ifdef ENABLE_RPMDB_BYRPMHEADER
+  state->ts = rpmtsFree(state->ts);
+#else
   if (state->db)
     state->db->close(state->db, 0);
   if (state->dbenv)


### PR DESCRIPTION
instead of opening the database directly.

This comes with some speed penalty as the header is loaded first and then reassembled to binary form. I am also working on the second step to actually use librpm to access the header which should get most of this speed back.
