### PR TITLE
Enable libsolv shared library, enable bz2/xz compression support

### DIFF
--- a/package/libsolv.changes
+++ b/package/libsolv.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Tue Jul 19 09:28:15 UTC 2016 - ngompa13@gmail.com
+
+- Enable libsolv shared library package to fix linking issues
+  with libxml2 and compression libraries
+
+-------------------------------------------------------------------
+Tue Jul 19 09:10:39 UTC 2016 - ngompa13@gmail.com
+
+- Enable bzip2 and xz/lzma compression support
+
+-------------------------------------------------------------------
 Tue Jun  7 11:24:47 CEST 2016 - mls@suse.de
 
 - fix bug in ignoreinst logic [bnc#983141]

--- a/package/libsolv.spec.in
+++ b/package/libsolv.spec.in
@@ -23,10 +23,12 @@ Source:         libsolv-%{version}.tar.bz2
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %bcond_without enable_static
-%bcond_without disable_shared
+%bcond_with disable_shared
 %bcond_without perl_binding
 %bcond_without python_binding
 %bcond_without ruby_binding
+%bcond_without bz2
+%bcond_without xz
 %bcond_with zypp
 
 %if 0%{?mandriva_version}
@@ -73,6 +75,21 @@ BuildRequires:  swig
 %global python_sitearch %(python -c "from distutils.sysconfig import get_python_lib; print get_python_lib(True);")
 BuildRequires:  python-devel
 BuildRequires:  swig
+%endif
+
+%if %{with bz2}
+%if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
+BuildRequires:  bzip2-devel
+%endif
+
+%if 0%{?suse_version}
+BuildRequires:  libbz2-devel
+%endif
+
+%endif
+
+%if %{with xz}
+BuildRequires:  xz-devel
 %endif
 
 Summary:        A new approach to package dependency solving
@@ -163,7 +180,7 @@ export CXXFLAGS="$CFLAGS"
 
 CMAKE_FLAGS=
 %if 0%{?fedora_version} || 0%{?rhel_version} >= 600 || 0%{?centos_version} >= 600
-CMAKE_FLAGS="-DFEDORA=1"
+CMAKE_FLAGS="-DFEDORA=1 -DENABLE_APPDATA=1 -DENABLE_COMPS=1"
 %endif
 %if 0%{?suse_version}
 CMAKE_FLAGS="-DSUSE=1 -DENABLE_APPDATA=1 -DENABLE_COMPS=1"
@@ -179,6 +196,8 @@ cmake   $CMAKE_FLAGS \
 	%{?with_perl_binding:-DENABLE_PERL=1} \
 	%{?with_python_binding:-DENABLE_PYTHON=1} \
 	%{?with_ruby_binding:-DENABLE_RUBY=1} \
+	%{?with_bz2:-DENABLE_BZIP2_COMPRESSION=1} \
+	%{?with_xz:-DENABLE_LZMA_COMPRESSION=1} \
 	%{?with_zypp:-DENABLE_SUSEREPO=1 -DENABLE_HELIXREPO=1} \
 	-DUSE_VENDORDIRS=1 \
 	-DCMAKE_SKIP_RPATH=1


### PR DESCRIPTION
When @M0ses and I started working on building libhif on openSUSE, we encountered issues linking libsolv with libhif because libxml2 symbols weren't resolving, and we were missing bzip2 and xz compression support.

This pull request resolves these issues.
