### PR TITLE
Also scan /usr/share/metainfo for appdata files

### DIFF
--- a/examples/solv/repoinfo_system_rpm.c
+++ b/examples/solv/repoinfo_system_rpm.c
@@ -27,7 +27,8 @@
 # define PRODUCTS_PATH "/etc/products.d"
 #endif
 #ifdef ENABLE_APPDATA
-# define APPDATA_PATH "/usr/share/appdata"
+# define APPDATA_PATH "/usr/share/metainfo"
+# define APPDATA_LEGACY_PATH "/usr/share/appdata"
 #endif
 
 static void
@@ -99,6 +100,12 @@ read_installed_rpm(struct repoinfo *cinfo)
   if (repo_add_appdata_dir(repo, APPDATA_PATH, REPO_REUSE_REPODATA | REPO_NO_INTERNALIZE | REPO_USE_ROOTDIR))
     {
       fprintf(stderr, "appdata reading failed: %s\n", pool_errstr(pool));
+      return 0;
+    }
+#elif defined(ENABLE_APPDATA) && defined(APPDATA_LEGACY_PATH)
+  if (repo_add_appdata_dir(repo, APPDATA_LEGACY_PATH, REPO_REUSE_REPODATA | REPO_NO_INTERNALIZE | REPO_USE_ROOTDIR))
+    {
+      fprintf(stderr, "appdata reading from legacy dir failed: %s\n", pool_errstr(pool));
       return 0;
     }
 #endif

--- a/tools/rpmdb2solv.c
+++ b/tools/rpmdb2solv.c
@@ -208,6 +208,7 @@ main(int argc, char **argv)
 #ifdef ENABLE_APPDATA
   if (add_appdata)
     repo_add_appdata_dir(repo, "/usr/share/appdata", REPO_USE_ROOTDIR | REPO_REUSE_REPODATA | REPO_NO_INTERNALIZE | APPDATA_SEARCH_UNINTERNALIZED_FILELIST);
+    repo_add_appdata_dir(repo, "/usr/share/metainfo", REPO_USE_ROOTDIR | REPO_REUSE_REPODATA | REPO_NO_INTERNALIZE | APPDATA_SEARCH_UNINTERNALIZED_FILELIST);
 #endif
   repodata_internalize(data);
 

--- a/tools/rpmdb2solv.c
+++ b/tools/rpmdb2solv.c
@@ -207,8 +207,8 @@ main(int argc, char **argv)
 
 #ifdef ENABLE_APPDATA
   if (add_appdata)
-    repo_add_appdata_dir(repo, "/usr/share/appdata", REPO_USE_ROOTDIR | REPO_REUSE_REPODATA | REPO_NO_INTERNALIZE | APPDATA_SEARCH_UNINTERNALIZED_FILELIST);
     repo_add_appdata_dir(repo, "/usr/share/metainfo", REPO_USE_ROOTDIR | REPO_REUSE_REPODATA | REPO_NO_INTERNALIZE | APPDATA_SEARCH_UNINTERNALIZED_FILELIST);
+    repo_add_appdata_dir(repo, "/usr/share/appdata", REPO_USE_ROOTDIR | REPO_REUSE_REPODATA | REPO_NO_INTERNALIZE | APPDATA_SEARCH_UNINTERNALIZED_FILELIST);
 #endif
   repodata_internalize(data);
 


### PR DESCRIPTION
According to the updated [appstream specification](https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html) :

>Applications are a special case here, because they are usually treated differently by software centers (and also for historical reasons). If your metainfo file covers only an application, as described in the AppData section, install it as /usr/share/metainfo/%{id}.appdata.xml.
>
>The /usr/share/appdata/ path must be scanned by AppStream tools as well, to support legacy applications installing metadata there. For new software components, it is advised not to use this directory. 

This PR ensures libsolv also scans the /usr/share/metainfo directory for appstream files in addition to the (now legacy) dir /usr/share/appdata supported currently.