### PR TITLE
Fixed unused count calculation.

### DIFF
--- a/src/queue.h
+++ b/src/queue.h
@@ -36,7 +36,7 @@ queue_empty(Queue *q)
 {
   if (q->alloc)
     {
-      q->left += (q->elements - q->alloc) + q->count;
+      q->left += ((q->elements - q->alloc)/sizeof(Id)) + q->count;
       q->elements = q->alloc;
     }
   else


### PR DESCRIPTION
Doing some porting of the static inline functions, I found the queue_empty code to incorrectly calculate the unused portion of the elements array.

The reproducer is along the lines of:
queue_init(queue);
queue_insert2(queue, 0, 1, 2);
queue_shift(queue)
queue_empty(queue);
queue_free(queue);

The print statements of our code before the fix:
start: Queue { elements: [1, 2], elements_ptr: 0x7fe291d000e0, count: 2, alloc_ptr: 0x7fe291d000e0, left: 6}
shift: Queue { elements: [2], elements_ptr: 0x7fe291d000e4, count: 1, alloc_ptr: 0x7fe291d000e0, left: 6}
empty: Queue { elements: [], elements_ptr: 0x7fe291d000e0, count: 0, alloc_ptr: 0x7fe291d000e0, left: 11}
free: Queue { elements: [], elements_ptr: 0x0, count: 0, alloc_ptr: 0x0, left: 0}

The print statements of our code after the fix:
start: Queue { elements: [1, 2], elements_ptr: 0x7fd2dad000e0, count: 2, alloc_ptr: 0x7fd2dad000e0, left: 6}
shift: Queue { elements: [2], elements_ptr: 0x7fd2dad000e4, count: 1, alloc_ptr: 0x7fd2dad000e0, left: 6}
empty: Queue { elements: [], elements_ptr: 0x7fd2dad000e0, count: 0, alloc_ptr: 0x7fd2dad000e0, left: 8}
free: Queue { elements: [], elements_ptr: 0x0, count: 0, alloc_ptr: 0x0, left: 0}