### PR TITLE
Enable more libsolv features and rework spec distro conditionals

### DIFF
--- a/package/libsolv.changes
+++ b/package/libsolv.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon May  8 13:15:09 UTC 2017 - ngompa13@gmail.com
+
+- Enable bzip2 and xz/lzma compression support
+- Enable complex/rich dependencies on distributions with RPM 4.13+
+- Simplified CentOS/RHEL conditionals
+- Added Mageia conditionals
+- Fixed a few spec portability issues
+
+-------------------------------------------------------------------
 Tue Apr 25 14:11:05 CEST 2017 - mls@suse.de
 
 - change queue resize code to use adaptive chunk sizes

--- a/package/libsolv.changes
+++ b/package/libsolv.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu May 11 12:41:07 UTC 2017 - ngompa13@gmail.com
+
+- Disable bzip2 and xz/lzma compression support for SLE <= 12
+
+-------------------------------------------------------------------
 Mon May  8 13:15:09 UTC 2017 - ngompa13@gmail.com
 
 - Enable bzip2 and xz/lzma compression support

--- a/package/libsolv.changes
+++ b/package/libsolv.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Sun May 28 13:32:15 UTC 2017 - ngompa13@gmail.com
+
+- Enable complex/rich dependencies for CentOS/RHEL 7, matching how
+  libsolv is configured there.
+
+-------------------------------------------------------------------
 Thu May 11 12:41:07 UTC 2017 - ngompa13@gmail.com
 
 - Disable bzip2 and xz/lzma compression support for SLE <= 12

--- a/package/libsolv.spec.in
+++ b/package/libsolv.spec.in
@@ -38,7 +38,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %bcond_with xz
 %endif
 
-%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?mageia} >= 6 || 0%{?suse_version} >= 1330
+%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?mageia} >= 6 || 0%{?suse_version} >= 1330
 %bcond_without richdeps
 %else
 %bcond_with richdeps

--- a/package/libsolv.spec.in
+++ b/package/libsolv.spec.in
@@ -28,20 +28,28 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %bcond_without python_binding
 %bcond_without python3_binding
 %bcond_without ruby_binding
+%bcond_without bz2
+%bcond_without xz
 %bcond_with zypp
+
+%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?mageia} >= 6 || 0%{?suse_version} >= 1330
+%bcond_without richdeps
+%else
+%bcond_with richdeps
+%endif
 
 %if 0%{?mandriva_version}
 # force this version on mandriva
 BuildRequires:  libneon0.26-devel
 %endif
-%if 0%{?fedora_version} || 0%{?rhel_version} >= 600 || 0%{?centos_version} >= 600
+%if 0%{?fedora} || 0%{?rhel} >= 6 || 0%{?mageia}
 BuildRequires:  db-devel
 %endif
 BuildRequires:  libxml2-devel
 %if 0%{?suse_version} && 0%{?suse_version} < 1100
 BuildRequires:  graphviz
 %endif
-%if 0%{?suse_version} > 1020
+%if 0%{?suse_version} > 1020 || 0%{?fedora} || 0%{?mageia}
 BuildRequires:  fdupes
 %endif
 BuildRequires:  cmake
@@ -51,7 +59,7 @@ BuildRequires:  zlib-devel
 
 %if %{with perl_binding}
 BuildRequires:  perl
-%if 0%{?fedora_version} || 0%{?rhel_version} >= 600 || 0%{?centos_version} >= 600
+%if 0%{?fedora} || 0%{?rhel} >= 6 || 0%{?mageia}
 BuildRequires:  perl-devel
 %endif
 BuildRequires:  swig
@@ -71,6 +79,22 @@ BuildRequires:  swig
 %global python3_sitearch %(python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(True))")
 BuildRequires:  python3-devel
 %endif
+
+%if %{with bz2}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?mageia}
+BuildRequires:  bzip2-devel
+%endif
+
+%if 0%{?suse_version}
+BuildRequires:  libbz2-devel
+%endif
+
+%endif
+
+%if %{with xz}
+BuildRequires:  xz-devel
+%endif
+
 
 Summary:        A new approach to package dependency solving
 License:        BSD-3-Clause
@@ -115,7 +139,7 @@ A new approach to package dependency solving.
 Summary:        Applications demoing the libsolv library
 Group:          System/Management
 Requires:       curl
-%if 0%{?fedora_version} || 0%{?rhel_version} >= 600 || 0%{?centos_version} >= 600
+%if 0%{?fedora} || 0%{?rhel} >= 6 || 0%{?mageia}
 Requires:       gnupg2
 %endif
 %if 0%{?suse_version}
@@ -166,8 +190,11 @@ export CFLAGS="$RPM_OPT_FLAGS"
 export CXXFLAGS="$CFLAGS"
 
 CMAKE_FLAGS=
-%if 0%{?fedora_version} || 0%{?rhel_version} >= 600 || 0%{?centos_version} >= 600
-CMAKE_FLAGS="-DFEDORA=1"
+%if 0%{?fedora} || 0%{?rhel} >= 6
+CMAKE_FLAGS="-DFEDORA=1 -DENABLE_APPDATA=1 -DENABLE_COMPS=1"
+%endif
+%if 0%{?mageia}
+CMAKE_FLAGS="-DMAGEIA=1 -DENABLE_APPDATA=1 -DENABLE_COMPS=1"
 %endif
 %if 0%{?suse_version}
 CMAKE_FLAGS="-DSUSE=1 -DENABLE_APPDATA=1 -DENABLE_COMPS=1"
@@ -185,10 +212,13 @@ cmake	$CMAKE_FLAGS \
 	%{?with_python_binding:-DENABLE_PYTHON=1} \
 	%{?with_python3_binding:-DENABLE_PYTHON3=1} \
 	%{?with_ruby_binding:-DENABLE_RUBY=1} \
+	%{?with_bz2:-DENABLE_BZIP2_COMPRESSION=1} \
+	%{?with_xz:-DENABLE_LZMA_COMPRESSION=1} \
+	%{?with_richdeps:-DENABLE_COMPLEX_DEPS=1} \
 	%{?with_zypp:-DENABLE_SUSEREPO=1 -DENABLE_HELIXREPO=1} \
 	-DUSE_VENDORDIRS=1 \
 	-DCMAKE_SKIP_RPATH=1
-make %{?jobs:-j %jobs}
+make %{?_smp_mflags}
 
 %install
 make DESTDIR=$RPM_BUILD_ROOT install

--- a/package/libsolv.spec.in
+++ b/package/libsolv.spec.in
@@ -28,9 +28,15 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %bcond_without python_binding
 %bcond_without python3_binding
 %bcond_without ruby_binding
+%bcond_with zypp
+
+%if ! ((0%{?suse_version} && 0%{?suse_version} < 1330 && ! 0%{?is_opensuse}) || 0%{?suse_version} == 1110)
 %bcond_without bz2
 %bcond_without xz
-%bcond_with zypp
+%else
+%bcond_with bz2
+%bcond_with xz
+%endif
 
 %if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?mageia} >= 6 || 0%{?suse_version} >= 1330
 %bcond_without richdeps
@@ -81,6 +87,7 @@ BuildRequires:  python3-devel
 %endif
 
 %if %{with bz2}
+
 %if 0%{?fedora} || 0%{?rhel} || 0%{?mageia}
 BuildRequires:  bzip2-devel
 %endif


### PR DESCRIPTION
- Enable bzip2 and xz/lzma compression support
- Enable complex/rich dependencies on distributions with RPM 4.13+
- Simplified CentOS/RHEL conditionals
- Added Mageia conditionals
- Fixed a few spec portability issues