### PR TITLE
Fix reading 64bit integer values from RPM header

### DIFF
--- a/ext/repo_rpmdb.c
+++ b/ext/repo_rpmdb.c
@@ -262,7 +262,7 @@ headint64array(RpmHead *h, int tag, int *cnt)
   for (o = 0; o < i; o++, d += 8)
     {
       unsigned int x = d[0] << 24 | d[1] << 16 | d[2] << 8 | d[3];
-      r[o] = (unsigned long long)x << 32 | (d[4] << 24 | d[5] << 16 | d[6] << 8 | d[7]);
+      r[o] = (unsigned long long)x << 32 | (unsigned int)(d[4] << 24 | d[5] << 16 | d[6] << 8 | d[7]);
     }
   return r;
 }
@@ -281,7 +281,7 @@ headint64(RpmHead *h, int tag)
     return 0;
   d = h->dp + o;
   i = d[0] << 24 | d[1] << 16 | d[2] << 8 | d[3];
-  return (unsigned long long)i << 32 | (d[4] << 24 | d[5] << 16 | d[6] << 8 | d[7]);
+  return (unsigned long long)i << 32 | (unsigned int)(d[4] << 24 | d[5] << 16 | d[6] << 8 | d[7]);
 }
 
 static unsigned int *


### PR DESCRIPTION
I tried fix DNF (https://bugzilla.redhat.com/show_bug.cgi?id=1300801) and found that bug is in libsolv.
The result of << and | must be cast to "unsigned". Or we get really bad result for some values.

Btw: Why libsolv reimplement librpm instead of using it?