### PR TITLE
bindings: do not leak Repo in __next__()

### DIFF
--- a/bindings/solv.i
+++ b/bindings/solv.i
@@ -2609,7 +2609,6 @@ rb_eval_string(
 #ifdef SWIGPERL
   perliter(solv::Pool_repo_iterator)
 #endif
-  %newobject __next__;
   Repo *__next__() {
     Pool *pool = $self->pool;
     if ($self->id >= pool->nrepos)


### PR DESCRIPTION
We don't create new object in __getitem__, why should we do it in __next__?

Closes: https://github.com/openSUSE/libsolv/issues/207
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>