### PR TITLE
_GNU_SOURCE should be defined before including any headers

### DIFF
--- a/src/poolvendor.c
+++ b/src/poolvendor.c
@@ -5,15 +5,14 @@
  * for further information
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 /* we need FNM_CASEFOLD */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <fnmatch.h>
 
 #include "pool.h"


### PR DESCRIPTION
per https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
"These directives must come before any #include of a system header file."

This actually causes a problem when compiling with newlib headers.