### PR TITLE
Fix compilation warnings

### DIFF
--- a/examples/solv/repoinfo_download.c
+++ b/examples/solv/repoinfo_download.c
@@ -13,6 +13,7 @@
 #include "repoinfo.h"
 #include "mirror.h"
 #include "checksig.h"
+#include "repoinfo_config_yum.h"
 #include "repoinfo_download.h"
 
 static inline int


### PR DESCRIPTION
examples/solv/repoinfo_download.c:95:18: warning: implicit declaration of function 'yum_substitute' [-Wimplicit-function-declaration]
        char *b = yum_substitute(cinfo->repo->pool, cinfo->baseurl);
                  ^~~~~~~~~~~~~~
examples/solv/repoinfo_download.c:95:18: warning: initialization makes pointer from integer without a cast [-Wint-conversion]