### PR TITLE
Sanitize PYTHONLIBS_VERSION_STRING before passing it to 'FIND_PACKAGE…

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -6,7 +6,12 @@ IF (ENABLE_PYTHON3 AND NOT DEFINED PythonLibs_FIND_VERSION)
 ENDIF (ENABLE_PYTHON3 AND NOT DEFINED PythonLibs_FIND_VERSION)
 
 FIND_PACKAGE (PythonLibs REQUIRED)
-FIND_PACKAGE (PythonInterp ${PYTHONLIBS_VERSION_STRING} REQUIRED)
+IF(PYTHONLIBS_VERSION_STRING MATCHES "^([0-9.]+)")
+    SET(python_version "${CMAKE_MATCH_1}")
+ELSE()
+    MESSAGE(FATAL_ERROR "PythonLibs version format unknown '${PYTHONLIBS_VERSION_STRING}'")
+ENDIF()
+FIND_PACKAGE (PythonInterp ${python_version} REQUIRED)
 
 EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib(True))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
 


### PR DESCRIPTION
… (PythonInterp).

 Obtained from libsolv_0.6.28-2 in Debian.

 Origin: https://gitlab.kitware.com/cmake/cmake/merge_requests/1047#note_288680
 Bug-Debian: https://bugs.debian.org/867514
 Author: Brad King
 Reviewed-by: gregor herrmann <gregoa@debian.org>
 Last-Update: 2017-07-22