### PR TITLE
Add missing definitions to libsolv for Mageia

### DIFF
--- a/examples/solv/deltarpm.c
+++ b/examples/solv/deltarpm.c
@@ -75,7 +75,7 @@ trydeltadownload(Solvable *s, const char *loc)
 	  seq = pool_tmpappend(pool, seq, "-", pool_lookup_str(pool, SOLVID_POS, DELTA_SEQ_NUM));
 	  if (strchr(seq, '\'') != 0)
 	    continue;
-#ifdef FEDORA
+#if defined(FEDORA) || defined(MAGEIA)
 	  sprintf(cmd, "/usr/bin/applydeltarpm -a '%s' -c -s '", archstr);
 #else
 	  sprintf(cmd, "/usr/bin/applydeltarpm -c -s '");
@@ -101,7 +101,7 @@ trydeltadownload(Solvable *s, const char *loc)
 	    continue;
 	  /* got it, now reconstruct */
 	  newfd = opentmpfile();
-#ifdef FEDORA
+#if defined(FEDORA) || defined(MAGEIA)
 	  sprintf(cmd, "applydeltarpm -a '%s' /dev/fd/%d /dev/fd/%d", archstr, fileno(fp), newfd);
 #else
 	  sprintf(cmd, "applydeltarpm /dev/fd/%d /dev/fd/%d", fileno(fp), newfd);

--- a/examples/solv/repoinfo.c
+++ b/examples/solv/repoinfo.c
@@ -18,13 +18,13 @@
 #include "repoinfo.h"
 #include "repoinfo_cache.h"
 
-#if defined(SUSE) || defined(FEDORA)
+#if defined(SUSE) || defined(FEDORA) || defined(MAGEIA)
 #include "repoinfo_config_yum.h"
 #endif
 #if defined(DEBIAN)
 #include "repoinfo_config_debian.h"
 #endif
-#if defined(MANDRIVA) || defined(MAGEIA)
+#if defined(MANDRIVA)
 #include "repoinfo_config_urpmi.h"
 #endif
 
@@ -80,7 +80,7 @@ free_repoinfos(struct repoinfo *repoinfos, int nrepoinfos)
       solv_free(cinfo->components);
     }
   solv_free(repoinfos);
-#if defined(SUSE) || defined(FEDORA)
+#if defined(SUSE) || defined(FEDORA) || defined(MAGEIA)
   yum_substitute((Pool *)0, 0);		/* free data */
 #endif
 }
@@ -89,10 +89,10 @@ struct repoinfo *
 read_repoinfos(Pool *pool, int *nrepoinfosp)
 {
   struct repoinfo *repoinfos = 0;
-#if defined(SUSE) || defined(FEDORA)
+#if defined(SUSE) || defined(FEDORA) || defined(MAGEIA)
   repoinfos = read_repoinfos_yum(pool, nrepoinfosp);
 #endif
-#if defined(MANDRIVA) || defined(MAGEIA)
+#if defined(MANDRIVA)
   repoinfos = read_repoinfos_urpmi(pool, nrepoinfosp);
 #endif
 #if defined(DEBIAN)

--- a/examples/solv/repoinfo_config_yum.c
+++ b/examples/solv/repoinfo_config_yum.c
@@ -48,7 +48,7 @@ yum_substitute(Pool *pool, char *line)
 	
 	      queue_init(&q);
 	      rpmstate = rpm_state_create(pool, pool_get_rootdir(pool));
-	      rpm_installedrpmdbids(rpmstate, "Providename", "redhat-release", &q);
+	      rpm_installedrpmdbids(rpmstate, "Providename", "system-release", &q);
 	      if (q.count)
 		{
 		  void *handle;
@@ -62,7 +62,7 @@ yum_substitute(Pool *pool, char *line)
 	      queue_free(&q);
 	      if (!releaseevr)
 		{
-		  fprintf(stderr, "no installed package provides 'redhat-release', cannot determine $releasever\n");
+		  fprintf(stderr, "no installed package provides 'system-release', cannot determine $releasever\n");
 		  exit(1);
 		}
 	    }

--- a/examples/solv/repoinfo_config_yum.c
+++ b/examples/solv/repoinfo_config_yum.c
@@ -1,4 +1,4 @@
-#if defined(SUSE) || defined(FEDORA)
+#if defined(SUSE) || defined(FEDORA) || defined(MAGEIA)
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,7 +14,7 @@
 #include "repoinfo_config_yum.h"
 
 
-#ifdef FEDORA
+#if defined(FEDORA) || defined(MAGEIA)
 # define REPOINFO_PATH "/etc/yum.repos.d"
 #endif
 #ifdef SUSE
@@ -160,7 +160,7 @@ read_repoinfos_yum(Pool *pool, int *nrepoinfosp)
 	      cinfo->type = TYPE_RPMMD;
 	      cinfo->autorefresh = 1;
 	      cinfo->priority = 99;
-#ifndef FEDORA
+#if !defined(FEDORA) && !defined(MAGEIA)
 	      cinfo->repo_gpgcheck = 1;
 #endif
 	      cinfo->metadata_expire = METADATA_EXPIRE;

--- a/examples/solv/repoinfo_download.c
+++ b/examples/solv/repoinfo_download.c
@@ -13,7 +13,7 @@
 #include "repoinfo.h"
 #include "mirror.h"
 #include "checksig.h"
-#ifdef FEDORA
+#if defined(FEDORA) || defined(MAGEIA)
 #include "repoinfo_config_yum.h"
 #endif
 #include "repoinfo_download.h"
@@ -92,7 +92,7 @@ curlfopen(struct repoinfo *cinfo, const char *file, int uncompress, const unsign
 	  fclose(fp);
 	  if (!cinfo->baseurl)
 	    return 0;
-#ifdef FEDORA
+#if defined(FEDORA) || defined(MAGEIA)
 	  if (strchr(cinfo->baseurl, '$'))
 	    {
 	      char *b = yum_substitute(cinfo->repo->pool, cinfo->baseurl);

--- a/examples/solv/solv.c
+++ b/examples/solv/solv.c
@@ -49,7 +49,7 @@
 #include "fileconflicts.h"
 #include "deltarpm.h"
 #endif
-#if defined(SUSE) || defined(FEDORA)
+#if defined(SUSE) || defined(FEDORA) || defined(MAGEIA)
 #include "patchjobs.h"
 #endif
 
@@ -195,7 +195,7 @@ usage(int r)
   fprintf(stderr, "    search:       search name/summary/description\n");
   fprintf(stderr, "    update:       update installed packages\n");
   fprintf(stderr, "    verify:       check dependencies of installed packages\n");
-#if defined(SUSE) || defined(FEDORA)
+#if defined(SUSE) || defined(FEDORA) || defined(MAGEIA)
   fprintf(stderr, "    patch:        install newest maintenance updates\n");
 #endif
   fprintf(stderr, "\n");
@@ -244,7 +244,7 @@ main(int argc, char **argv)
       mainmode = MODE_INSTALL;
       mode = SOLVER_INSTALL;
     }
-#if defined(SUSE) || defined(FEDORA)
+#if defined(SUSE) || defined(FEDORA) || defined(MAGEIA)
   else if (!strcmp(argv[0], "patch"))
     {
       mainmode = MODE_PATCH;
@@ -638,7 +638,7 @@ main(int argc, char **argv)
       exit(0);
     }
 
-#if defined(SUSE) || defined(FEDORA)
+#if defined(SUSE) || defined(FEDORA) || defined(MAGEIA)
   if (mainmode == MODE_PATCH)
     add_patchjobs(pool, &job);
 #endif
@@ -667,7 +667,7 @@ main(int argc, char **argv)
 rerunsolver:
   solv = solver_create(pool);
   solver_set_flag(solv, SOLVER_FLAG_SPLITPROVIDES, 1);
-#ifdef FEDORA
+#if defined(FEDORA) || defined(MAGEIA)
   solver_set_flag(solv, SOLVER_FLAG_ALLOW_VENDORCHANGE, 1);
 #endif
   if (mainmode == MODE_ERASE)

--- a/ext/repo_rpmdb.c
+++ b/ext/repo_rpmdb.c
@@ -1186,7 +1186,7 @@ rpmdbid2db(unsigned char *db, Id id, int byteswapped)
 #endif
 }
 
-#ifdef FEDORA
+#if defined(FEDORA) || defined(MAGEIA)
 int
 serialize_dbenv_ops(struct rpmdbstate *state)
 {
@@ -1227,7 +1227,7 @@ opendbenv(struct rpmdbstate *state)
 
   if (db_env_create(&dbenv, 0))
     return pool_error(state->pool, 0, "db_env_create: %s", strerror(errno));
-#if defined(FEDORA) && (DB_VERSION_MAJOR >= 5 || (DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 5))
+#if (defined(FEDORA) || defined(MAGEIA)) && (DB_VERSION_MAJOR >= 5 || (DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 5))
   dbenv->set_thread_count(dbenv, 8);
 #endif
   snprintf(dbpath, PATH_MAX, "%s/var/lib/rpm", rootdir ? rootdir : "");
@@ -1241,7 +1241,7 @@ opendbenv(struct rpmdbstate *state)
     }
   else
     {
-#ifdef FEDORA
+#if defined(FEDORA) || defined(MAGEIA)
       int serialize_fd = serialize_dbenv_ops(state);
       r = dbenv->open(dbenv, dbpath, DB_CREATE|DB_INIT_CDB|DB_INIT_MPOOL, 0644);
       if (serialize_fd >= 0)
@@ -1263,13 +1263,13 @@ opendbenv(struct rpmdbstate *state)
 static void
 closedbenv(struct rpmdbstate *state)
 {
-#ifdef FEDORA
+#if defined(FEDORA) || defined(MAGEIA)
   uint32_t eflags = 0;
 #endif
 
   if (!state->dbenv)
     return;
-#ifdef FEDORA
+#if defined(FEDORA) || defined(MAGEIA)
   (void)state->dbenv->get_open_flags(state->dbenv, &eflags);
   if (!(eflags & DB_PRIVATE))
     {


### PR DESCRIPTION
This PR adds the missing definitions to libsolv to make it behave as expected on Mageia (that is, like it does on Fedora). This includes adjustments to the example `solv` tool as well as enabling codepaths previously guarded out for only Fedora, despite also applying to Mageia now.