### PR TITLE
policy.c: Fix solver_prune_to_highest_prio_per_name

### DIFF
--- a/src/policy.c
+++ b/src/policy.c
@@ -210,6 +210,8 @@ solver_prune_to_highest_prio_per_name(Solver *solv, Queue *plist)
 	  queue_push(&pq, plist->elements[i]);
 	  name = pool->solvables[pq.elements[0]].name;
 	}
+      else
+	  queue_push(&pq, plist->elements[i]);
     }
   if (pq.count > 2)
     solver_prune_to_highest_prio(solv, &pq);

--- a/test/testcases/recommendations/recommended_conflicts.t
+++ b/test/testcases/recommendations/recommended_conflicts.t
@@ -1,0 +1,16 @@
+repo system 0 empty
+repo available 0 testtags <inline>
+#>=Pkg: A 1 1 noarch
+#>=Rec: B
+#>=Pkg: B 1 1 noarch
+#>=Pkg: B 3 1 noarch
+#>=Con: A
+#>=Pkg: B 2 1 noarch
+system i686 rpm system
+
+solverflags ignorerecommended
+job install name A
+
+result transaction,recommended,problems <inline>
+#>install A-1-1.noarch@available
+#>recommended B-2-1.noarch@available

--- a/test/testcases/recommendations/recommended_multirepo.t
+++ b/test/testcases/recommendations/recommended_multirepo.t
@@ -1,0 +1,19 @@
+repo system 0 empty
+repo available 0 testtags <inline>
+#>=Pkg: A 1 1 noarch
+#>=Rec: B
+#>=Pkg: B 1 1 noarch
+#>=Pkg: B 3 1 noarch
+#>=Pkg: B 2 1 noarch
+repo other 0 testtags <inline>
+#>=Pkg: B 4 1 noarch
+#>=Pkg: B 6 1 noarch
+#>=Pkg: B 5 1 noarch
+system i686 rpm system
+
+solverflags ignorerecommended
+job install name A
+
+result transaction,recommended,problems <inline>
+#>install A-1-1.noarch@available
+#>recommended B-6-1.noarch@other

--- a/test/testcases/recommendations/recommended_oldversion.t
+++ b/test/testcases/recommendations/recommended_oldversion.t
@@ -1,0 +1,15 @@
+repo system 0 empty
+repo available 0 testtags <inline>
+#>=Pkg: A 1 1 noarch
+#>=Rec: B < 3
+#>=Pkg: B 1 1 noarch
+#>=Pkg: B 3 1 noarch
+#>=Pkg: B 2 1 noarch
+system i686 rpm system
+
+solverflags ignorerecommended
+job install name A
+
+result transaction,recommended,problems <inline>
+#>install A-1-1.noarch@available
+#>recommended B-2-1.noarch@available

--- a/test/testcases/recommendations/recommended_targeted.t
+++ b/test/testcases/recommendations/recommended_targeted.t
@@ -1,0 +1,15 @@
+repo system 0 empty
+repo available 0 testtags <inline>
+#>=Pkg: A 1 1 noarch
+#>=Rec: B = 2-1
+#>=Pkg: B 1 1 noarch
+#>=Pkg: B 3 1 noarch
+#>=Pkg: B 2 1 noarch
+system i686 rpm system
+
+solverflags ignorerecommended
+job install name A
+
+result transaction,recommended,problems <inline>
+#>install A-1-1.noarch@available
+#>recommended B-2-1.noarch@available

--- a/test/testcases/recommendations/recommended_version.t
+++ b/test/testcases/recommendations/recommended_version.t
@@ -1,0 +1,15 @@
+repo system 0 empty
+repo available 0 testtags <inline>
+#>=Pkg: A 1 1 noarch
+#>=Rec: B
+#>=Pkg: B 1 1 noarch
+#>=Pkg: B 3 1 noarch
+#>=Pkg: B 2 1 noarch
+system i686 rpm system
+
+solverflags ignorerecommended
+job install name A
+
+result transaction,recommended,problems <inline>
+#>install A-1-1.noarch@available
+#>recommended B-3-1.noarch@available

--- a/test/testcases/recommendations/suggested_conflicts.t
+++ b/test/testcases/recommendations/suggested_conflicts.t
@@ -1,0 +1,16 @@
+repo system 0 empty
+repo available 0 testtags <inline>
+#>=Pkg: A 1 1 noarch
+#>=Sug: B
+#>=Pkg: B 1 1 noarch
+#>=Pkg: B 3 1 noarch
+#>=Con: A
+#>=Pkg: B 2 1 noarch
+system i686 rpm system
+
+solverflags ignorerecommended
+job install name A
+
+result transaction,recommended,problems <inline>
+#>install A-1-1.noarch@available
+#>suggested B-2-1.noarch@available

--- a/test/testcases/recommendations/suggested_multirepo.t
+++ b/test/testcases/recommendations/suggested_multirepo.t
@@ -1,0 +1,19 @@
+repo system 0 empty
+repo available 0 testtags <inline>
+#>=Pkg: A 1 1 noarch
+#>=Sug: B
+#>=Pkg: B 1 1 noarch
+#>=Pkg: B 3 1 noarch
+#>=Pkg: B 2 1 noarch
+repo other 0 testtags <inline>
+#>=Pkg: B 4 1 noarch
+#>=Pkg: B 6 1 noarch
+#>=Pkg: B 5 1 noarch
+system i686 rpm system
+
+solverflags ignorerecommended
+job install name A
+
+result transaction,recommended,problems <inline>
+#>install A-1-1.noarch@available
+#>suggested B-6-1.noarch@other

--- a/test/testcases/recommendations/suggested_oldversion.t
+++ b/test/testcases/recommendations/suggested_oldversion.t
@@ -1,0 +1,15 @@
+repo system 0 empty
+repo available 0 testtags <inline>
+#>=Pkg: A 1 1 noarch
+#>=Sug: B < 3
+#>=Pkg: B 1 1 noarch
+#>=Pkg: B 3 1 noarch
+#>=Pkg: B 2 1 noarch
+system i686 rpm system
+
+solverflags ignorerecommended
+job install name A
+
+result transaction,recommended,problems <inline>
+#>install A-1-1.noarch@available
+#>suggested B-2-1.noarch@available

--- a/test/testcases/recommendations/suggested_targeted.t
+++ b/test/testcases/recommendations/suggested_targeted.t
@@ -1,0 +1,15 @@
+repo system 0 empty
+repo available 0 testtags <inline>
+#>=Pkg: A 1 1 noarch
+#>=Sug: B = 2-1
+#>=Pkg: B 1 1 noarch
+#>=Pkg: B 3 1 noarch
+#>=Pkg: B 2 1 noarch
+system i686 rpm system
+
+solverflags ignorerecommended
+job install name A
+
+result transaction,recommended,problems <inline>
+#>install A-1-1.noarch@available
+#>suggested B-2-1.noarch@available

--- a/test/testcases/recommendations/suggested_version.t
+++ b/test/testcases/recommendations/suggested_version.t
@@ -1,0 +1,15 @@
+repo system 0 empty
+repo available 0 testtags <inline>
+#>=Pkg: A 1 1 noarch
+#>=Sug: B
+#>=Pkg: B 1 1 noarch
+#>=Pkg: B 3 1 noarch
+#>=Pkg: B 2 1 noarch
+system i686 rpm system
+
+solverflags ignorerecommended
+job install name A
+
+result transaction,recommended,problems <inline>
+#>install A-1-1.noarch@available
+#>suggested B-3-1.noarch@available


### PR DESCRIPTION
- Fixed logic so that all packages with the same name are pushed to the queue
  of packages to be pruned instead of just the first package with that name.
- This fixes a bug where the best version of recommended and suggested packages
  were not being returned.
- Added tests to check that this does fix the problem with recommended and
  suggested packages mentioned above.