### PR TITLE
Add SOLVER_FAVOR support to prune_to_best_version()

### DIFF
--- a/src/policy.h
+++ b/src/policy.h
@@ -38,10 +38,10 @@ extern void policy_update_recommendsmap(Solver *solv);
 
 extern void policy_create_obsolete_index(Solver *solv);
 
-extern void pool_best_solvables(Pool *pool, Queue *plist, int flags);
+extern void pool_best_solvables(Solver *solv, Queue *plist, int flags);
 
 /* internal, do not use */
-extern void prune_to_best_version(Pool *pool, Queue *plist);
+extern void prune_to_best_version(Solver *solv, Queue *plist);
 extern void policy_prefer_favored(Solver *solv, Queue *plist);
 
 

--- a/src/rules.c
+++ b/src/rules.c
@@ -3647,7 +3647,7 @@ find_obsolete_group(Solver *solv, Id obs, Queue *q)
     }
   /* find names so that we can build groups */
   queue_init_clone(&qn, q);
-  prune_to_best_version(solv->pool, &qn);
+  prune_to_best_version(solv, &qn);
 #if 0
 {
   for (i = 0; i < qn.count; i++)


### PR DESCRIPTION
SOLVER_FAVOR currently only works for alternatives (i.e. after the candidates are pruned to the best versions).

This is a first attempt to change. I added SOLVER_FAVOR support to function prune_to_best_version(). That means favored package has precedence over package with higher version.

So we can favor package with specific version, but:
1. "favormap" and "isdisfavormap" are stored in Solver data. **So I changed arguments of prune_to_best_version() and  pool_best_solvables() to pass Solver instead of Pool.
Another solution is move "favormap" and "isdisfavormap" to the Pool. Is it good idea?**

2. **SOLVER_FAVOR is very weak yet.** Candidates are pruned to the best arch, to recommended, repo priority, ... May be adding support to other functions helps (will make SOLVER_FAVOR stronger).  Probably I try it.

**Examples of tests:**
**Simple situation - favored package won.**
poolflags implicitobsoleteusescolors
solverflags allowdowngrade allowvendorchange keepexplicitobsoletes bestobeypolicy keeporphans yumobsoletes
job install oneof iftop-1.0-0.14.pre4.fc25.x86_64@updates iftop-1.0-0.11.pre4.fc24.x86_64@fedora [setevr,setarch]
job favor pkg iftop-1.0-0.11.pre4.fc24.x86_64@fedora
result transaction,problems solver.result
result:
install iftop-1.0-0.11.pre4.fc24.x86_64@fedora

**Instaling chromium, 3 packages must have the same version, only one package is mark as favored -  higher version won.**
poolflags implicitobsoleteusescolors
solverflags allowdowngrade allowvendorchange keepexplicitobsoletes bestobeypolicy keeporphans yumobsoletes
job install oneof chromium-53.0.2785.116-1.fc25.x86_64@fedora chromium-59.0.3071.104-1.fc25.x86_64@updates [setevr,setarch]
job favor pkg chromium-53.0.2785.116-1.fc25.x86_64@fedora
result transaction,problems solver.result
result:
install chromium-59.0.3071.104-1.fc25.x86_64@updates
install chromium-libs-59.0.3071.104-1.fc25.x86_64@updates
install chromium-libs-media-59.0.3071.104-1.fc25.x86_64@updates
install u2f-hidraw-policy-1.0.2-2.fc24.x86_64@fedora

**Instaling chromium, 3 packages must have the same version, two packages are mark as favored -  favored packages won.**
poolflags implicitobsoleteusescolors
solverflags allowdowngrade allowvendorchange keepexplicitobsoletes bestobeypolicy keeporphans yumobsoletes
job install oneof chromium-59.0.3071.104-1.fc25.x86_64@updates chromium-53.0.2785.116-1.fc25.x86_64@fedora [setevr,setarch]
job favor pkg chromium-53.0.2785.116-1.fc25.x86_64@fedora
job favor pkg chromium-libs-media-53.0.2785.116-1.fc25.x86_64@fedora
result transaction,problems solver.result
result:
install chromium-53.0.2785.116-1.fc25.x86_64@fedora
install chromium-libs-53.0.2785.116-1.fc25.x86_64@fedora
install chromium-libs-media-53.0.2785.116-1.fc25.x86_64@fedora
install u2f-hidraw-policy-1.0.2-2.fc24.x86_64@fedora
