### PR TITLE
repo_rpmdb.c: increase MAX_HDR_CNT and MAX_HDR_DSIZE

### DIFF
--- a/ext/repo_rpmdb.c
+++ b/ext/repo_rpmdb.c
@@ -170,8 +170,8 @@
 #define MAX_SIG_CNT		0x100000
 #define MAX_SIG_DSIZE		0x100000
 
-#define MAX_HDR_CNT		0x100000
-#define MAX_HDR_DSIZE		0x2000000
+#define MAX_HDR_CNT		0x200000
+#define MAX_HDR_DSIZE		0x4000000
 
 typedef struct rpmhead {
   int cnt;


### PR DESCRIPTION
We encountered 'corrupt rpm' issues when installing extreme big RPM
packages like the kernel-devsrc package of Yocto project.

It can be fixed by increasing MAX_HDR_CNT and MAX_HDR_DSIZE per test.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>