### PR TITLE
Add support for cleandeps in updates resulting from SOLVER_INSTALL jobs.

### DIFF
--- a/src/solver.c
+++ b/src/solver.c
@@ -3359,6 +3359,13 @@ solver_solve(Solver *solv, Queue *job)
 		  MAPSET(&solv->fixmap, p - installed->start);
 		}
 	      break;
+	    case SOLVER_INSTALL:
+	      if ((solv->install_also_updates || (how & SOLVER_ORUPDATE)) && (how & SOLVER_CLEANDEPS))
+		{
+		  FOR_REPO_SOLVABLES(installed, p, s)
+		    add_cleandeps_updatepkg(solv, p);
+		}
+	      break;
 	    case SOLVER_UPDATE:
 	      if (select == SOLVER_SOLVABLE_ALL)
 		{

--- a/test/testcases/cleandeps/cleandeps_in.t
+++ b/test/testcases/cleandeps/cleandeps_in.t
@@ -8,7 +8,28 @@ repo test 0 testtags <inline>
 #>=Pkg: B1 1 1 noarch
 #>=Pkg: B2 1 1 noarch
 system i686 rpm system
+
+# check targeted
 job install name A = 2 [cleandeps]
+result transaction,problems,cleandeps <inline>
+#>cleandeps B1-1-1.noarch@system
+#>erase B1-1-1.noarch@system
+#>install B2-1-1.noarch@test
+#>upgrade A-1-1.noarch@system A-2-1.noarch@test
+
+# check orupdate
+nextjob
+job install name A [cleandeps,orupdate]
+result transaction,problems,cleandeps <inline>
+#>cleandeps B1-1-1.noarch@system
+#>erase B1-1-1.noarch@system
+#>install B2-1-1.noarch@test
+#>upgrade A-1-1.noarch@system A-2-1.noarch@test
+
+# check installalsoupdates
+nextjob
+solverflags installalsoupdates
+job install name A [cleandeps]
 result transaction,problems,cleandeps <inline>
 #>cleandeps B1-1-1.noarch@system
 #>erase B1-1-1.noarch@system


### PR DESCRIPTION
- Call add_cleandeps_updatepkg() for SOLVER_INSTALL jobs with SOLVER_CLEANDEPS
when SOLVER_FLAG_INSTALL_ALSO_UPDATES is set or when the job's how has SOLVER_ORUPDATE.
- Adds two test cases for these scanerios.