### PR TITLE
Fix pkgid extraction when adding rpm file to repo if built with librpm

### DIFF
--- a/ext/repo_rpmdb.c
+++ b/ext/repo_rpmdb.c
@@ -2005,7 +2005,7 @@ repo_add_rpm(Repo *repo, const char *rpm, int flags)
 	  unsigned char *chksum;
 	  unsigned int chksumsize;
 	  chksum = headbinary(state.rpmhead, SIGTAG_MD5, &chksumsize);
-	  if (chksum && chksumsize == 16)
+	  if (chksum && chksumsize >= 16)
 	    {
 	      pkgidtype = REPOKEY_TYPE_MD5;
 	      memcpy(pkgid, chksum, 16);


### PR DESCRIPTION
MD5 checksum is extracted from first header of rpm file and used as pkgid if `repo_add_rpm()` function is called with `RPM_ADD_WITH_PKGID` flag.

If `libsolv` is built with `ENABLE_RPMPKG_LIBRPM` option, rpm file header is read using `librpm`'s `headerImport()` function with `HEADERIMPORT_FAST` flag.

This flag causes `librpm` to use simplified algorithm to find actual data size in index entry.
This algorithm just uses difference between offsets in consecutive index entries, assuming that there are no gaps between entries in header data.

Unfortunately, in some cases there are gaps, so returned data length for MD5 checksum may be slightly greater than 16 bytes. This causes check for checksum size to be equal to 16 to fail, resulting in pkgid not being added.

This change relaxes check for returned MD5 checksum size, allowing it to be greater that 16.

Alternatively, this problem can be fixed by not using `HEADERIMPORT_FAST`, but it will slow down package import.

[Example of rpm package causing this problem.](https://dl.fedoraproject.org/pub/fedora/linux/releases/27/Everything/x86_64/os/Packages/p/perl-Text-Balanced-2.03-394.fc27.noarch.rpm)