### PR TITLE
source/binary rpm detection heuristic when ENABLE_RPMPKG_LIBRPM used

### DIFF
--- a/ext/repo_rpmdb.c
+++ b/ext/repo_rpmdb.c
@@ -457,7 +457,15 @@ headbinary(RpmHead *h, int tag, unsigned int *sizep)
 static int
 headissourceheuristic(RpmHead *h)
 {
-  return headerIsSource(h);
+  int issource = 0;
+  char **dn;
+  int dcnt;
+  dn = headstringarray(h, TAG_DIRNAMES, &dcnt);
+  if (dn) {
+      issource = dcnt == 1 && dn[0] && !*dn[0];
+      solv_free(dn);
+  }
+  return issource;
 }
 
 static inline void


### PR DESCRIPTION
The headerIsSource() simply checks a presence of the RPMTAG_SOURCERPM
tag in package header, which is not really useful in this context.
This patch provides the same "heuristic" as the librpm uses for
detecting source/binary rpm.

Relevant bug: https://bugzilla.redhat.com/show_bug.cgi?id=1572338