### PR TITLE
Bump debian control.tar size limit

### DIFF
--- a/ext/repo_deb.c
+++ b/ext/repo_deb.c
@@ -599,8 +599,11 @@ repo_add_deb(Repo *repo, const char *deb, int flags)
       fclose(fp);
       return 0;
     }
+  /* dpkg has no actual maximum size for the control.tar member, so this
+   * just keeps from allocating arbitrarily large amounts of memory.
+   */
   clen = atoi((char *)buf + 8 + 60 + vlen + 48);
-  if (clen <= 0 || clen >= 0x100000)
+  if (clen <= 0 || clen >= 0x1000000)
     {
       pool_error(pool, -1, "%s: control.tar has illegal size", deb);
       fclose(fp);


### PR DESCRIPTION
Increase the arbitrary control.tar.gz limit from 1 MB to 16 MB. We came
across an openjdk-7-jdk package that had a 2.4MB control.tar.gz and
libsolv failed to parse it. dpkg doesn't actually apply a limit to these
files.