### PR TITLE
Fix out of bounds compilation warning

### DIFF
--- a/src/policy.c
+++ b/src/policy.c
@@ -1236,7 +1236,7 @@ urpm_reorder(Solver *solv, Queue *plist)
 		    {
 		      char kn[256];
 		      Id p, pp, knid;
-		      memcpy(kn, "kernel", 8);
+		      memcpy(kn, "kernel", 7);
 		      memcpy(kn + 6, flavor, release - flavor + 1);
 		      memcpy(kn + 6 + (release - flavor) + 1, sn, flavor - sn);
 		      strcpy(kn + 6 + (release + 1 - sn), release);


### PR DESCRIPTION
When compiling with -D_FORTIFY_SOURCE=2, gcc raises the following
warning:

    In file included from /usr/include/string.h:494,
                     from /build/libsolv/src/libsolv-0.6.35/src/policy.c:16:
    In function ‘memcpy’,
        inlined from ‘urpm_reorder.isra.18’ at /build/libsolv/src/libsolv-0.6.35/src/policy.c:1239:9:
    /usr/include/bits/string_fortified.h:34:10: warning: ‘__builtin_memcpy’ forming offset 8 is out of the bounds [0, 7] [-Warray-bounds]
       return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Culprit code is:

     memcpy(kn, "kernel", 8);
     memcpy(kn + 6, flavor, release - flavor + 1);

The first memcpy copies 8 bytes whereas the string "kernel" as only 7
bytes. It does not have serious consequence since the second memcpy
overwrites the unwanted byte. Anyway, it is better to fix it.