### PR TITLE
Fix repo2solv to work with Busybox find tool

### DIFF
--- a/tools/repo2solv.c
+++ b/tools/repo2solv.c
@@ -169,9 +169,9 @@ read_plaindir_repo(Repo *repo, const char *dir)
 	  close(fds[1]);
 	}
       if (recursive)
-	execl("/usr/bin/find", ".", "-name", ".", "-o", "-name", ".*", "-prune", "-o", "-name", "*.delta.rpm", "-o", "-name", "*.patch.rpm", "-o", "-name", "*.rpm", "-a", "-type", "f", "-print0", (char *)0);
+	execl("/usr/bin/find", "/usr/bin/find", ".", "-name", ".", "-o", "-name", ".*", "-prune", "-o", "-name", "*.delta.rpm", "-o", "-name", "*.patch.rpm", "-o", "-name", "*.rpm", "-a", "-type", "f", "-print0", (char *)0);
       else
-	execl("/usr/bin/find", ".", "-maxdepth", "1", "-name", ".", "-o", "-name", ".*", "-prune", "-o", "-name", "*.delta.rpm", "-o", "-name", "*.patch.rpm", "-o", "-name", "*.rpm", "-a", "-type", "f", "-print0", (char *)0);
+	execl("/usr/bin/find", "/usr/bin/find", ".", "-maxdepth", "1", "-name", ".", "-o", "-name", ".*", "-prune", "-o", "-name", "*.delta.rpm", "-o", "-name", "*.patch.rpm", "-o", "-name", "*.rpm", "-a", "-type", "f", "-print0", (char *)0);
       perror("/usr/bin/find");
       _exit(1);
     }


### PR DESCRIPTION
Busybox find got quite confused by "." as arg0. Added a new instance of
dot as first real parameter as I could assume that being the original
intention.