### PR TITLE
solver_solve: only disfavor recommends if there are any

### DIFF
--- a/src/solver.c
+++ b/src/solver.c
@@ -3920,7 +3920,7 @@ solver_solve(Solver *solv, Queue *job)
   else
     solv->yumobsrules = solv->yumobsrules_end = solv->nrules;
 
-  if (solv->havedisfavored && solv->strongrecommends)
+  if (solv->havedisfavored && solv->strongrecommends && solv->recommendsruleq)
     solver_addrecommendsrules(solv);
   else
     solv->recommendsrules = solv->recommendsrules_end = solv->nrules;


### PR DESCRIPTION
In a repo that have pkg 'a' and 'b' available, and 'b' is disfavored,
but 'a' doesn't recommend 'b', libsolv segfaults on
solver_addrecommendsrules, since solv->recommendsruleq is null. Only
call solver_addrecommendsrules if there are recommends rules.

Signed-off-by: Alejandro del Castillo <alejandro.delcastillo@ni.com>