### PR TITLE
repodata: Avoid crash in repodata_add_dirstr() if dir==0

### DIFF
--- a/src/repodata.c
+++ b/src/repodata.c
@@ -2941,7 +2941,8 @@ repodata_set_kv(Repodata *data, Id solvid, Id keyname, Id keytype, KeyValue *kv)
         repodata_add_dirnumnum(data, solvid, keyname, kv->id, kv->num, kv->num2);
       break;
     case REPOKEY_TYPE_DIRSTRARRAY:
-      repodata_add_dirstr(data, solvid, keyname, kv->id, kv->str);
+      if (kv->id)
+        repodata_add_dirstr(data, solvid, keyname, kv->id, kv->str);
       break;
     case_CHKSUM_TYPES:
       repodata_set_bin_checksum(data, solvid, keyname, keytype, (const unsigned char *)kv->str);


### PR DESCRIPTION
repodata_add_dirstr() crashes if called with dir==0 so it should not
be called with that value. Previously it was correctly worked around
in commit 3edcaace14c71804ac571068276fe81880880478, then it was forgotten
in commit 72e8b9af78a98e7226d1d30e3f00848c8b4c36d9. This causes random
crashes, e.g.: https://bugzilla.redhat.com/show_bug.cgi?id=1640278
or https://bugzilla.redhat.com/show_bug.cgi?id=1652017.