### PR TITLE
add star even if build string is present

### DIFF
--- a/src/conda.c
+++ b/src/conda.c
@@ -645,8 +645,6 @@ pool_conda_matchspec(Pool *pool, const char *name)
 	  if (!build)
 	    version += 2;
 	}
-      else if (build)
-	version += 1;
       else
 	{
 	  for (p = version + 1; p < versionend; p++)


### PR DESCRIPTION
In order to install a definition such as this one:

`python =3.7 h381d211_0`

I needed to remove this condition so that this gets translated to 

`python 3.7* h381d211_0`

I'm not sure what purpose the condition on the build string was serving. Let me know if this needs a different kind of fix.