### PR TITLE
fix up json parsing and comparison of build version

### DIFF
--- a/ext/repo_conda.c
+++ b/ext/repo_conda.c
@@ -58,8 +58,8 @@ parse_package(struct parsedata *pd, struct solv_jsonparser *jp, char *kfn)
     {
       if (type == JP_STRING && !strcmp(jp->key, "build"))
 	repodata_add_poolstr_array(data, handle, SOLVABLE_BUILDFLAVOR, jp->value);
-      else if (type == JP_STRING && !strcmp(jp->key, "build_number"))
-	repodata_set_str(data, handle, SOLVABLE_BUILDVERSION, jp->value);
+      else if (type == JP_NUMBER && !strcmp(jp->key, "build_number"))
+	repodata_set_num(data, handle, SOLVABLE_BUILDVERSION, strtoull(jp->value, 0, 10));
       else if (type == JP_ARRAY && !strcmp(jp->key, "depends"))
 	type = parse_deps(pd, jp, &s->requires);
       else if (type == JP_ARRAY && !strcmp(jp->key, "requires"))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ SET (libsolv_HEADERS
 
 IF (ENABLE_CONDA)
     SET (libsolv_SRCS ${libsolv_SRCS} conda.c)
+    SET (libsolv_HEADERS ${libsolv_HEADERS} conda.h)
 ENDIF (ENABLE_CONDA)
 
 IF (NOT MSVC)

--- a/src/policy.c
+++ b/src/policy.c
@@ -834,14 +834,9 @@ move_installed_to_front(Pool *pool, Queue *plist)
 static int
 pool_buildversioncmp(Pool *pool, Solvable *s1, Solvable *s2)
 {
-  const char *bv2, *bv1 = solvable_lookup_str(s1, SOLVABLE_BUILDVERSION);
-  if (bv1)
-    {
-      bv2 = solvable_lookup_str(s2, SOLVABLE_BUILDVERSION);
-      if (bv1 != bv2)
-	return pool_evrcmp_str(pool, bv1, bv2, EVRCMP_COMPARE);
-    }
-  return 0;
+  const unsigned long bv1 = solvable_lookup_num(s1, SOLVABLE_BUILDVERSION, 0);
+  const unsigned long bv2 = solvable_lookup_num(s2, SOLVABLE_BUILDVERSION, 0);
+  return (bv1 > bv2) - (bv1 < bv2);
 }
 
 static int


### PR DESCRIPTION
The build version was never parsed from the json (as it's a JP_NUMBER type) and consequently, the sorting after build version did not work. 

This was evident when trying to install `ncurses` which should pull in ncurses 6.1 1002 but chose ncurses 6.1 0

This seems to fix it.