### PR TITLE
Fix lto-bytecode errors:

### DIFF
--- a/package/libsolv.changes
+++ b/package/libsolv.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jul 10 07:48:10 UTC 2019 - Martin Liška <mliska@suse.cz>
+
+- Add -ffat-lto-objects to $optflags as the package provides
+  static libraries
+- Remove NO_BRP_STRIP_DEBUG=true as brp-15-strip-debug will
+  not strip debug info for archives
+
+-------------------------------------------------------------------
 Thu Jun 13 16:15:39 CEST 2019 - mls@suse.de
 
 - make cleandeps jobs on patterns work [bnc#1137977]

--- a/package/libsolv.spec.in
+++ b/package/libsolv.spec.in
@@ -207,6 +207,7 @@ Perl bindings for libsolv.
 %setup -q
 
 %build
+%global _lto_cflags %{_lto_cflags} -ffat-lto-objects
 export CFLAGS="%{optflags}"
 export CXXFLAGS="$CFLAGS"
 
@@ -256,10 +257,6 @@ ln -s repo2solv %{buildroot}/%{_bindir}/repo2solv.sh
 %if %{with python3}
 %py3_compile %{buildroot}/%{python3_sitearch}
 %endif
-%endif
-%if %{with static}
-# we want to leave the .a file untouched
-export NO_BRP_STRIP_DEBUG=true
 %endif
 
 %check


### PR DESCRIPTION
[  250s] libsolv-devel.x86_64: E: lto-bytecode (Badness: 10000) /usr/lib64/libsolv.a
[  250s] libsolv-devel.x86_64: E: lto-bytecode (Badness: 10000) /usr/lib64/libsolvext.a

- Add -ffat-lto-objects to $optflags as the package provides
  static libraries
- Remove NO_BRP_STRIP_DEBUG=true as brp-15-strip-debug will
  not strip debug info for archives