### PR TITLE
add parsing of the packages.conda key

### DIFF
--- a/ext/repo_conda.c
+++ b/ext/repo_conda.c
@@ -163,6 +163,10 @@ parse_main(struct parsedata *pd, struct solv_jsonparser *jp)
 	type = parse_packages(pd, jp);
       if (type == JP_ARRAY && !strcmp("packages", jp->key))
 	type = parse_packages2(pd, jp);
+      if (type == JP_OBJECT && !strcmp("packages.conda", jp->key))
+	type = parse_packages(pd, jp);
+      if (type == JP_ARRAY && !strcmp("packages.conda", jp->key))
+	type = parse_packages2(pd, jp);
       else
 	type = jsonparser_skip(jp, type);
     }


### PR DESCRIPTION
conda introduced a new package format (called `.conda`).

In order to stay backward compatible (older versions of conda do not support un-archiving this new package format) they introduced a new key (`packages.conda`).

This PR just adds 4 lines of code to additionally parse the packages found in this key. 

One thing I am not sure of is what will happen if a package is found in _both_, the `packages` and `packages.conda` key. I am currently looking for clarification from the conda folks if we can expect that to never happen.

If this happens, how could we drop the old format packages?