### PR TITLE
de-prioritize track_features (conda)

### DIFF
--- a/ext/repo_conda.c
+++ b/ext/repo_conda.c
@@ -107,6 +107,13 @@ parse_package(struct parsedata *pd, struct solv_jsonparser *jp, char *kfn)
 	    ts /= 1000;
 	  repodata_set_num(data, handle, SOLVABLE_BUILDTIME, ts);
 	}
+      else if (type == JP_STRING && !strcmp(jp->key, "track_features"))
+	{
+	  unsigned long long count = 1;
+	  for (unsigned long long i=0; jp->value[i]; i++)
+	    count += (jp->value[i] == ',' || jp->value[i] == ' ');
+	  repodata_set_num(data, handle, SOLVABLE_TRACK_FEATURES, count);
+	}
       else
 	type = jsonparser_skip(jp, type);
     }

--- a/src/knownid.h
+++ b/src/knownid.h
@@ -266,6 +266,7 @@ KNOWNID(UPDATE_STATUS,			"update:status"),		/* "stable", "testing", ...*/
 KNOWNID(LIBSOLV_SELF_DESTRUCT_PKG,      "libsolv-self-destruct-pkg()"),	/* this package will self-destruct on installation */
 
 KNOWNID(SOLVABLE_CONSTRAINS,		"solvable:constrains"),		/* conda */
+KNOWNID(SOLVABLE_TRACK_FEATURES,	"solvable:track_features"),	/* conda */
 
 KNOWNID(ID_NUM_INTERNAL,		0)
 

--- a/src/policy.c
+++ b/src/policy.c
@@ -846,6 +846,11 @@ pool_buildversioncmp(Pool *pool, Solvable *s1, Solvable *s2)
 static int
 pool_buildflavorcmp(Pool *pool, Solvable *s1, Solvable *s2)
 {
+  unsigned long long tf1 = solvable_lookup_num(s1, SOLVABLE_TRACK_FEATURES, 0);
+  unsigned long long tf2 = solvable_lookup_num(s2, SOLVABLE_TRACK_FEATURES, 0);
+  if (tf1 != tf2)
+    return tf1 > tf2 ? -1 : 1;
+
   const char *f1 = solvable_lookup_str(s1, SOLVABLE_BUILDFLAVOR);
   const char *f2 = solvable_lookup_str(s2, SOLVABLE_BUILDFLAVOR);
   if (!f1 && !f2)


### PR DESCRIPTION
Conda has a ancient key called `track_features` which was previously used to decide between different "features sets". However, this usage was dropped as it was making the SAT problem too hard & slow (mutex packages are used to achieve a similar effect nowadays).

However, there is one property of the "track_features" key – that it can be used to _deprioritize_ packages, and that is still being used today (cf. https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#track-features )

So this PR attempts to read the `track_features` key if it is avaible in the package, and stores a number in the repo/pool. In the comparison step, depending on how many track_features have been found, the package get's de-prioritized.

Note: the track_features key has a value that is a string, which can contain multiple track features seperated by either a space or `,`. 