### PR TITLE
Add support for znver1 and znver1_32 architectures

### DIFF
--- a/src/poolarch.c
+++ b/src/poolarch.c
@@ -60,6 +60,8 @@ static const char *archpolicies[] = {
   "geode",	"geode:i586:i486:i386",
   "ppc64iseries", "ppc64iseries:ppc64:ppc",
   "ppc64pseries", "ppc64pseries:ppc64:ppc",
+  "znver1",	"znver1:x86_64:athlon:i686:i586:i486:i386",
+  "znver1_32",	"znver1_32:athlon:i686:i586:i486:i386",
 #endif
   0
 };


### PR DESCRIPTION
OpenMandriva offers a Ryzen-optimized variant of the distribution, so libsolv needs to understand this architecture on OpenMandriva.

Depends on https://github.com/rpm-software-management/rpm/pull/1035