### PR TITLE
conda: take subprio into account for initial sort

### DIFF
--- a/src/policy.c
+++ b/src/policy.c
@@ -906,10 +906,14 @@ prune_to_best_version(Pool *pool, Queue *plist)
       if (r == 0 && has_package_link(pool, s))
         r = pool_link_evrcmp(pool, best, s);
 #endif
+#ifdef ENABLE_CONDA
+      if (r == 0 && pool->disttype == DISTTYPE_CONDA)
+	r = best->repo->subpriority - s->repo->subpriority;
       if (r == 0 && pool->disttype == DISTTYPE_CONDA)
 	r = pool_buildversioncmp(pool, best, s);
       if (r == 0 && pool->disttype == DISTTYPE_CONDA)
 	r = pool_buildflavorcmp(pool, best, s);
+#endif
       if (r < 0)
 	best = s;
     }


### PR DESCRIPTION
@mlschroe what do you think about this?

This produces slightly nicer results for conda environments. Conda has two modes: 

- strict channel priority (always choose package from highest prio channel, works beautifully with libsolv)
- dynamic prio: take highest evr. However, often we have the same versions on multiple channels, and users still expect mamba to choose the one from e.g. conda-forge, so adding a sub-priority and using it in this sort gives a slight preference to those packages from the added channel.