### PR TITLE
rpmdb: Also detect rpmdb.sqlite in /usr/share/rpm

### DIFF
--- a/ext/repo_rpmdb_librpm.h
+++ b/ext/repo_rpmdb_librpm.h
@@ -46,7 +46,7 @@ static void
 detect_dbpath(struct rpmdbstate *state)
 {
   state->dbpath = access_rootdir(state, "/var/lib/rpm", W_OK) == -1
-                  && access_rootdir(state, "/usr/share/rpm/Packages", R_OK) == 0
+                  && (access_rootdir(state, "/usr/share/rpm/Packages", R_OK) == 0 || access_rootdir(state, "/usr/share/rpm/rpmdb.sqlite", R_OK) == 0)
                   ? "/usr/share/rpm" : "/var/lib/rpm";
 }
 


### PR DESCRIPTION
See: https://bugzilla.redhat.com/show_bug.cgi?id=1838691

This is obviously adding to a tower of hacks; what we really
want is for this logic to live in librpm and be standardized.
But in order to fix the immediate issue of detecting the rpmdb
on rpm-ostree based systems (and any others that use `/usr/share/rpm`),
add the sqlite path to detection.

See also http://lists.rpm.org/pipermail/rpm-maint/2017-October/006681.html