### PR TITLE
Add extra arg to write_testcase for libzypp

### DIFF
--- a/bindings/solv.i
+++ b/bindings/solv.i
@@ -3685,7 +3685,7 @@ rb_eval_string(
   }
 
   bool write_testcase(const char *dir) {
-    return testcase_write($self, dir, TESTCASE_RESULT_TRANSACTION | TESTCASE_RESULT_PROBLEMS, 0, 0);
+    return testcase_write($self, dir, TESTCASE_RESULT_TRANSACTION | TESTCASE_RESULT_PROBLEMS, 0, 0, 0);
   }
 
   Queue raw_decisions(int filter=0) {

--- a/examples/solv/solv.c
+++ b/examples/solv/solv.c
@@ -710,7 +710,7 @@ rerunsolver:
       if (testcase)
 	{
 	  printf("Writing solver testcase:\n");
-	  if (!testcase_write(solv, testcase, TESTCASE_RESULT_TRANSACTION | TESTCASE_RESULT_PROBLEMS, 0, 0))
+	  if (!testcase_write(solv, testcase, TESTCASE_RESULT_TRANSACTION | TESTCASE_RESULT_PROBLEMS, 0, 0, 0))
 	    printf("%s\n", pool_errstr(pool));
 	  testcase = 0;
 	}

--- a/ext/testcase.c
+++ b/ext/testcase.c
@@ -1582,7 +1582,7 @@ testcase_solverresult(Solver *solv, int resultflags)
 
 
 static int
-testcase_write_mangled(Solver *solv, const char *dir, int resultflags, const char *testcasename, const char *resultname)
+testcase_write_mangled(Solver *solv, const char *dir, int resultflags, const char *testcasename, const char *resultname, char **repoFileNames)
 {
   Pool *pool = solv->pool;
   Repo *repo;
@@ -1626,6 +1626,14 @@ testcase_write_mangled(Solver *solv, const char *dir, int resultflags, const cha
       cmd = pool_tmpappend(pool, cmd, priobuf, " ");
       cmd = pool_tmpappend(pool, cmd, "testtags ", out);
       strqueue_push(&sq, cmd);
+
+			if (repoFileNames)
+			{
+				repoFileNames[repoid] = solv_malloc( strlen( out ) + 1 );
+				strncpy(repoFileNames[repoid], out, strlen(out));
+				repoFileNames[repoid][strlen(out)] = 0;
+			}
+
       out = pool_tmpjoin(pool, dir, "/", out);
       if (!(fp = solv_xfopen(out, "w")))
 	{
@@ -1810,7 +1818,7 @@ testcase_write_mangled(Solver *solv, const char *dir, int resultflags, const cha
 }
 
 int
-testcase_write(Solver *solv, const char *dir, int resultflags, const char *testcasename, const char *resultname)
+testcase_write(Solver *solv, const char *dir, int resultflags, const char *testcasename, const char *resultname, char **repoFileNames )
 {
   Pool *pool = solv->pool;
   int i, r, repoid;
@@ -1844,7 +1852,7 @@ testcase_write(Solver *solv, const char *dir, int resultflags, const char *testc
 	}
       repo->name = buf;
     }
-  r = testcase_write_mangled(solv, dir, resultflags, testcasename, resultname);
+  r = testcase_write_mangled(solv, dir, resultflags, testcasename, resultname, repoFileNames);
   for (repoid = 1; repoid < pool->nrepos; repoid++)
     {
       Repo *repo = pool_id2repo(pool, repoid);

--- a/ext/testcase.h
+++ b/ext/testcase.h
@@ -39,6 +39,6 @@ extern const char *testcase_getsolverflags(Solver *solv);
 extern int testcase_setsolverflags(Solver *solv, const char *str);
 extern void testcase_resetsolverflags(Solver *solv);
 extern char *testcase_solverresult(Solver *solv, int flags);
-extern int testcase_write(Solver *solv, const char *dir, int resultflags, const char *testcasename, const char *resultname);
+extern int testcase_write(Solver *solv, const char *dir, int resultflags, const char *testcasename, const char *resultname, char **repoFileNames );
 extern Solver *testcase_read(Pool *pool, FILE *fp, const char *testcase, Queue *job, char **resultp, int *resultflagsp);
 extern char *testcase_resultdiff(const char *result1, const char *result2);

--- a/tools/testsolv.c
+++ b/tools/testsolv.c
@@ -298,7 +298,7 @@ main(int argc, char **argv)
 	    {
 	      int pcnt = solver_solve(solv, &job);
 	      if (writetestcase)
-		testcase_write(solv, writetestcase, resultflags, 0, 0);
+		testcase_write(solv, writetestcase, resultflags, 0, 0, 0);
 	      if (pcnt && solq.count)
 		{
 		  int i, taken = 0;


### PR DESCRIPTION
In order for libzypp/zypper to write its own testcase informations we need
a way to get the repo data filenames. This patch adds a extra argument
to receive the filenames for each repository.