### PR TITLE
Updateinfo metadata with multiple collections in a single pkglist (nevra/nsvca construction)

### DIFF
--- a/ext/repo_updateinfoxml.c
+++ b/ext/repo_updateinfoxml.c
@@ -110,7 +110,7 @@ struct parsedata {
   Id handle;
   Solvable *solvable;
   time_t buildtime;
-  Id collhandle;
+  Id pkghandle;
   struct solv_xmlparser xmlp;
   struct joindata jd;
 };
@@ -326,12 +326,12 @@ startElement(struct solv_xmlparser *xmlp, int state, const char *name, const cha
 	    solvable->conflicts = repo_addid_dep(pd->repo, solvable->conflicts, id, 0);
 	  }
 
-        /* who needs the collection anyway? */
-        pd->collhandle = repodata_new_handle(pd->data);
-	repodata_set_id(pd->data, pd->collhandle, UPDATE_COLLECTION_NAME, n);
-	repodata_set_id(pd->data, pd->collhandle, UPDATE_COLLECTION_EVR, evr);
+        /* UPDATE_COLLECTION is misnamed, it should have been UPDATE_PACKAGE */
+        pd->pkghandle = repodata_new_handle(pd->data);
+	repodata_set_id(pd->data, pd->pkghandle, UPDATE_COLLECTION_NAME, n);
+	repodata_set_id(pd->data, pd->pkghandle, UPDATE_COLLECTION_EVR, evr);
 	if (a)
-	  repodata_set_id(pd->data, pd->collhandle, UPDATE_COLLECTION_ARCH, a);
+	  repodata_set_id(pd->data, pd->pkghandle, UPDATE_COLLECTION_ARCH, a);
         break;
       }
     case STATE_MODULE:
@@ -428,14 +428,14 @@ endElement(struct solv_xmlparser *xmlp, int state, char *content)
       break;
 
     case STATE_PACKAGE:
-      repodata_add_flexarray(pd->data, pd->handle, UPDATE_COLLECTION, pd->collhandle);
-      pd->collhandle = 0;
+      repodata_add_flexarray(pd->data, pd->handle, UPDATE_COLLECTION, pd->pkghandle);
+      pd->pkghandle = 0;
       break;
 
       /* <filename>libntlm-0.4.2-1.fc8.x86_64.rpm</filename> */
       /* <filename>libntlm-0.4.2-1.fc8.x86_64.rpm</filename> */
     case STATE_FILENAME:
-      repodata_set_str(pd->data, pd->collhandle, UPDATE_COLLECTION_FILENAME, content);
+      repodata_set_str(pd->data, pd->pkghandle, UPDATE_COLLECTION_FILENAME, content);
       break;
 
       /* <reboot_suggested>True</reboot_suggested> */
@@ -444,7 +444,7 @@ endElement(struct solv_xmlparser *xmlp, int state, char *content)
 	{
 	  /* FIXME: this is per-package, the global flag should be computed at runtime */
 	  repodata_set_void(pd->data, pd->handle, UPDATE_REBOOT);
-	  repodata_set_void(pd->data, pd->collhandle, UPDATE_REBOOT);
+	  repodata_set_void(pd->data, pd->pkghandle, UPDATE_REBOOT);
 	}
       break;
 
@@ -454,7 +454,7 @@ endElement(struct solv_xmlparser *xmlp, int state, char *content)
 	{
 	  /* FIXME: this is per-package, the global flag should be computed at runtime */
 	  repodata_set_void(pd->data, pd->handle, UPDATE_RESTART);
-	  repodata_set_void(pd->data, pd->collhandle, UPDATE_RESTART);
+	  repodata_set_void(pd->data, pd->pkghandle, UPDATE_RESTART);
 	}
       break;
 
@@ -464,7 +464,7 @@ endElement(struct solv_xmlparser *xmlp, int state, char *content)
 	{
 	  /* FIXME: this is per-package, the global flag should be computed at runtime */
 	  repodata_set_void(pd->data, pd->handle, UPDATE_RELOGIN);
-	  repodata_set_void(pd->data, pd->collhandle, UPDATE_RELOGIN);
+	  repodata_set_void(pd->data, pd->pkghandle, UPDATE_RELOGIN);
 	}
       break;
     default:

--- a/src/knownid.h
+++ b/src/knownid.h
@@ -268,6 +268,8 @@ KNOWNID(LIBSOLV_SELF_DESTRUCT_PKG,      "libsolv-self-destruct-pkg()"),	/* this 
 KNOWNID(SOLVABLE_CONSTRAINS,		"solvable:constrains"),		/* conda */
 KNOWNID(SOLVABLE_TRACK_FEATURES,	"solvable:track_features"),	/* conda */
 
+KNOWNID(UPDATE_COLLECTIONLIST,      "update:collectionlist"),  /* list of UPDATE_COLLECTION (actually packages) and UPDATE_MODULE */
+
 KNOWNID(ID_NUM_INTERNAL,		0)
 
 #ifdef KNOWNID_INITIALIZE


### PR DESCRIPTION
In rhel there are updateinfo metadata with multiple collections in a single pkglist, example:
```
<pkglist>
  <collection>
    <module name="mod1" stream="master" version="2" context="c1" arch="x86_64"/>
    <package name="pkg-a" version="1" release="2" epoch="0" arch="x86_64" src="http://www.foo.org">
      <filename>pkg-a-1-2.spec</filename>
    </package>
  </collection>
  <collection>
    <module name="mod2" stream="master" version="2" context="c2" arch="x86_64"/>
    <package name="pkg-b" version="1" release="2" epoch="0" arch="x86_64" src="http://www.foo.org">
      <filename>pkg-b-1-2.spec</filename>
    </package>
    <package name="pkg-lib" version="1" release="2" epoch="0" arch="x86_64" src="http://www.foo.org">
      <filename>pkg-lib-1-2.spec</filename>
    </package>
  </collection>
</pkglist>
```

Currently the information about collections is lost during parsing, all packages end up together and all modules as well, I am trying to fix that by adding the `collectionlist` which contains modules and packages for each collection.
```
update:collectionlist:
  update:module:
    mod1:master:2:c1:x86_64
  update:collection:
    pkg-a-1-2.x86_64

  update:module:
    mod2:master:2:c2:x86_64
  update:collection:
    pkg-b-1-2.x86_64
    pkg-lib-1-2.x86_64
```

I don't really like the nevra and nsvca construction, the approach in conflicting PR https://github.com/openSUSE/libsolv/pull/402 is much cleaner but I am not sure if correct. In case both are wrong can you point me in the right direction?