### PR TITLE
Updateinfo metadata with multiple collections in a single pkglist (using only ids)

### DIFF
--- a/ext/repo_updateinfoxml.c
+++ b/ext/repo_updateinfoxml.c
@@ -110,7 +110,7 @@ struct parsedata {
   Id handle;
   Solvable *solvable;
   time_t buildtime;
-  Id collhandle;
+  Id pkghandle;
   struct solv_xmlparser xmlp;
   struct joindata jd;
 };
@@ -326,12 +326,12 @@ startElement(struct solv_xmlparser *xmlp, int state, const char *name, const cha
 	    solvable->conflicts = repo_addid_dep(pd->repo, solvable->conflicts, id, 0);
 	  }
 
-        /* who needs the collection anyway? */
-        pd->collhandle = repodata_new_handle(pd->data);
-	repodata_set_id(pd->data, pd->collhandle, UPDATE_COLLECTION_NAME, n);
-	repodata_set_id(pd->data, pd->collhandle, UPDATE_COLLECTION_EVR, evr);
+        /* UPDATE_COLLECTION is misnamed, it should have been UPDATE_PACKAGE */
+        pd->pkghandle = repodata_new_handle(pd->data);
+	repodata_set_id(pd->data, pd->pkghandle, UPDATE_COLLECTION_NAME, n);
+	repodata_set_id(pd->data, pd->pkghandle, UPDATE_COLLECTION_EVR, evr);
 	if (a)
-	  repodata_set_id(pd->data, pd->collhandle, UPDATE_COLLECTION_ARCH, a);
+	  repodata_set_id(pd->data, pd->pkghandle, UPDATE_COLLECTION_ARCH, a);
         break;
       }
     case STATE_MODULE:
@@ -428,14 +428,14 @@ endElement(struct solv_xmlparser *xmlp, int state, char *content)
       break;
 
     case STATE_PACKAGE:
-      repodata_add_flexarray(pd->data, pd->handle, UPDATE_COLLECTION, pd->collhandle);
-      pd->collhandle = 0;
+      repodata_add_flexarray(pd->data, pd->handle, UPDATE_COLLECTION, pd->pkghandle);
+      pd->pkghandle = 0;
       break;
 
       /* <filename>libntlm-0.4.2-1.fc8.x86_64.rpm</filename> */
       /* <filename>libntlm-0.4.2-1.fc8.x86_64.rpm</filename> */
     case STATE_FILENAME:
-      repodata_set_str(pd->data, pd->collhandle, UPDATE_COLLECTION_FILENAME, content);
+      repodata_set_str(pd->data, pd->pkghandle, UPDATE_COLLECTION_FILENAME, content);
       break;
 
       /* <reboot_suggested>True</reboot_suggested> */
@@ -444,7 +444,7 @@ endElement(struct solv_xmlparser *xmlp, int state, char *content)
 	{
 	  /* FIXME: this is per-package, the global flag should be computed at runtime */
 	  repodata_set_void(pd->data, pd->handle, UPDATE_REBOOT);
-	  repodata_set_void(pd->data, pd->collhandle, UPDATE_REBOOT);
+	  repodata_set_void(pd->data, pd->pkghandle, UPDATE_REBOOT);
 	}
       break;
 
@@ -454,7 +454,7 @@ endElement(struct solv_xmlparser *xmlp, int state, char *content)
 	{
 	  /* FIXME: this is per-package, the global flag should be computed at runtime */
 	  repodata_set_void(pd->data, pd->handle, UPDATE_RESTART);
-	  repodata_set_void(pd->data, pd->collhandle, UPDATE_RESTART);
+	  repodata_set_void(pd->data, pd->pkghandle, UPDATE_RESTART);
 	}
       break;
 
@@ -464,7 +464,7 @@ endElement(struct solv_xmlparser *xmlp, int state, char *content)
 	{
 	  /* FIXME: this is per-package, the global flag should be computed at runtime */
 	  repodata_set_void(pd->data, pd->handle, UPDATE_RELOGIN);
-	  repodata_set_void(pd->data, pd->collhandle, UPDATE_RELOGIN);
+	  repodata_set_void(pd->data, pd->pkghandle, UPDATE_RELOGIN);
 	}
       break;
     default:

--- a/src/knownid.h
+++ b/src/knownid.h
@@ -268,6 +268,8 @@ KNOWNID(LIBSOLV_SELF_DESTRUCT_PKG,      "libsolv-self-destruct-pkg()"),	/* this 
 KNOWNID(SOLVABLE_CONSTRAINS,		"solvable:constrains"),		/* conda */
 KNOWNID(SOLVABLE_TRACK_FEATURES,	"solvable:track_features"),	/* conda */
 
+KNOWNID(UPDATE_COLLECTIONLIST,      "update:collectionlist"),  /* list of UPDATE_COLLECTION (actually packages) and UPDATE_MODULE */
+
 KNOWNID(ID_NUM_INTERNAL,		0)
 
 #ifdef KNOWNID_INITIALIZE


### PR DESCRIPTION
This is a conflicting PR for https://github.com/openSUSE/libsolv/pull/401 that tries to fix the same problem with updateinfo metadata with multiple collections in a single pkglist.

I would prefer this approach but I don't know if it is allowed/correct.
I am able to get the information about collections in libdnf using two nested `dataiterators` but when I try to `dumpsolv`  such a solv file it doesn't work, reporting:
```
data_read_id_max: id too large (14/7)
could not read repository: data_read_id_max: id too large (14/7)
```
I think it has something to do with the `schematas` but I can't seem to figure it out.