### PR TITLE
package: Set LD_LIBRARY_PATH for tests to work against shared library

### DIFF
--- a/package/libsolv.spec.in
+++ b/package/libsolv.spec.in
@@ -263,6 +263,11 @@ export NO_BRP_STRIP_DEBUG=true
 %endif
 
 %check
+%if %{with shared}
+# The test suite doesn't automatically know to look at the "built"
+# library, so we force it by creating an LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=%{buildroot}%{_libdir}
+%endif
 make ARGS=--output-on-failure test
 
 %if %{with shared}


### PR DESCRIPTION
When a shared library is built, we need to have the test suite attempt to
use our newly built shared library. Without this, it fails with unresolved
symbols.