### PR TITLE
Home rpmdb

### DIFF
--- a/ext/libsolvext.ver
+++ b/ext/libsolvext.ver
@@ -54,6 +54,7 @@ SOLV_1.0 {
 		rpm_query_num;
 		rpm_stat_database;
 		rpm_state_create;
+		rpm_state_create_real;
 		rpm_state_free;
 		solv_fmemopen;
 		solv_verify_sig;

--- a/ext/repo_rpmdb.h
+++ b/ext/repo_rpmdb.h
@@ -27,6 +27,7 @@ extern Id repo_add_rpm(Repo *repo, const char *rpm, int flags);
 #define RPM_ADD_WITH_CHANGELOG	(1 << 17)
 #define RPM_ADD_FILTERED_FILELIST (1 << 18)
 #define RPMDB_KEEP_GPG_PUBKEY   (1 << 19)
+#define RPMDB_USE_HOMEDIR	(1 << 20)
 
 #define RPMDB_EMPTY_REFREPO	(1 << 30)	/* internal */
 
@@ -35,8 +36,14 @@ extern Id repo_add_rpm(Repo *repo, const char *rpm, int flags);
 #define RPM_ITERATE_FILELIST_WITHCOL	(1 << 2)
 #define RPM_ITERATE_FILELIST_NOGHOSTS	(1 << 3)
 
-/* create and free internal state, rootdir is the rootdir of the rpm database */
+/*
+ * create and free internal state, rootdir is the rootdir of the rpm database
+ * and use_homedir a boolean value that prefers a rpmdb located the user's home directory
+ * instead of the system locations, but will fall back to the latter if there is no
+ * database in the user's home directory
+ */
 extern void *rpm_state_create(Pool *pool, const char *rootdir);
+extern void *rpm_state_create_real(Pool *pool, const char *rootdir, int use_homedir);
 extern void *rpm_state_free(void *rpmstate);
 
 /* return all matching rpmdbids */

--- a/ext/repo_rpmdb_bdb.h
+++ b/ext/repo_rpmdb_bdb.h
@@ -44,6 +44,8 @@ struct rpmdbstate {
 
   RpmHead *rpmhead;	/* header storage space */
   unsigned int rpmheadsize;
+  int use_homedir;	/* force usage of private rpmdb in home dir */
+  int open_home_rpmdb;	/* internal; tracks rpmdb in homedir usage */
 
   int dbenvopened;	/* database environment opened */
   int pkgdbopened;	/* package database openend */
@@ -72,9 +74,28 @@ access_rootdir(struct rpmdbstate *state, const char *dir, int mode)
 static void
 detect_dbpath(struct rpmdbstate *state)
 {
+
+  char *dbpath_prefix = solv_dupjoin(state->rootdir, "/", 0);
+
   state->dbpath = access_rootdir(state, "/var/lib/rpm", W_OK) == -1
-                  && access_rootdir(state, "/usr/share/rpm/Packages", R_OK) == 0
-                  ? "/usr/share/rpm" : "/var/lib/rpm";
+                    && access_rootdir(state, "/usr/share/rpm/Packages", R_OK) == 0
+                    ? "/usr/share/rpm" : "/var/lib/rpm";
+
+  if (state->open_home_rpmdb)
+    {
+      char *home_dir = get_homedir();
+
+      if (home_dir)
+        {
+          state->dbpath = solv_dupjoin(dbpath_prefix, home_dir, "/.rpmdb/");
+
+          solv_free(home_dir);
+          home_dir = NULL;
+        }
+    }
+
+  solv_free(dbpath_prefix);
+  dbpath_prefix = NULL;
 }
 
 static int
@@ -84,6 +105,7 @@ stat_database_name(struct rpmdbstate *state, char *dbname, struct stat *statbuf,
   if (!state->dbpath)
     detect_dbpath(state);
   dbpath = solv_dupjoin(state->rootdir, state->dbpath, dbname);
+
   if (stat(dbpath, statbuf))
     {
       if (seterror)

--- a/tools/rpmdb2solv.c
+++ b/tools/rpmdb2solv.c
@@ -41,8 +41,9 @@ static void
 usage(int status)
 {
   fprintf(stderr, "\nUsage:\n"
-	  "rpmdb2solv [-P] [-C] [-n] [-b <basefile>] [-p <productsdir>] [-r <root>]\n"
+	  "rpmdb2solv [-P] [-C] [-n] [H] [-b <basefile>] [-p <productsdir>] [-r <root>]\n"
 	  " -n : No packages, do not read rpmdb, useful to only parse products\n"
+	  " -H : use rpmdb in user's home directory\n"
 	  " -p <productsdir> : Scan <productsdir> for .prod files, representing installed products\n"
 	  " -r <root> : Prefix rpmdb path and <productsdir> with <root>\n"
 	  " -o <solv> : Write .solv to file instead of stdout\n"
@@ -63,6 +64,7 @@ main(int argc, char **argv)
   int c, percent = 0;
   int nopacks = 0;
   int add_changelog = 0;
+  int homedir = 0;
   const char *root = 0;
   const char *refname = 0;
 #ifdef ENABLE_SUSEREPO
@@ -83,7 +85,7 @@ main(int argc, char **argv)
    * parse arguments
    */
   
-  while ((c = getopt(argc, argv, "ACPhnkxXr:p:o:")) >= 0)
+  while ((c = getopt(argc, argv, "ACPhnHkxXr:p:o:")) >= 0)
     switch (c)
       {
       case 'h':
@@ -127,6 +129,9 @@ main(int argc, char **argv)
       case 'C':
 	add_changelog = 1;
 	break;
+      case 'H':
+        homedir = 1;
+        break;
       default:
 	usage(1);
       }
@@ -171,6 +176,8 @@ main(int argc, char **argv)
 	flags |= RPMDB_REPORT_PROGRESS;
       if (add_changelog)
 	flags |= RPM_ADD_WITH_CHANGELOG;
+      if (homedir)
+        flags |= RPMDB_USE_HOMEDIR;
       if (repo_add_rpmdb_reffp(repo, reffp, flags))
 	{
 	  fprintf(stderr, "rpmdb2solv: %s\n", pool_errstr(pool));


### PR DESCRIPTION
rpm on Debian is patched to not use the default system-wide rpm database. Instead, the dbpath is hardcoded to ~/.rpmdb. This is based on previous original work of author in https://lists.debian.org/debian-devel/2019/09/msg00218.html.