### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ matrix:
         apt:
           packages:
           - cmake
+    - os: linux
+      arch: ppc64le
+      addons:
+        apt:
+          packages:
+          - cmake
     - os: osx
       osx_image: xcode9.4
       compiler: clang


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.