### PR TITLE
Update long usage in regex polyfill

### DIFF
--- a/win32/regexec.c
+++ b/win32/regexec.c
@@ -231,7 +231,7 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string,
     pbytes = sizeof(*reach_pos) * tnfa->num_states;
     xbytes = sizeof(regoff_t) * num_tags;
     total_bytes =
-      (sizeof(long) - 1) * 4 /* for alignment paddings */
+      (sizeof(size_t) - 1) * 4 /* for alignment paddings */
       + (rbytes + xbytes * tnfa->num_states) * 2 + tbytes + pbytes;
 
     /* Allocate the memory. */
@@ -242,16 +242,16 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string,
     /* Get the various pointers within tmp_buf (properly aligned). */
     tmp_tags = (void *)buf;
     tmp_buf = buf + tbytes;
-    tmp_buf += ALIGN(tmp_buf, long);
+    tmp_buf += ALIGN(tmp_buf, size_t);
     reach_next = (void *)tmp_buf;
     tmp_buf += rbytes;
-    tmp_buf += ALIGN(tmp_buf, long);
+    tmp_buf += ALIGN(tmp_buf, size_t);
     reach = (void *)tmp_buf;
     tmp_buf += rbytes;
-    tmp_buf += ALIGN(tmp_buf, long);
+    tmp_buf += ALIGN(tmp_buf, size_t);
     reach_pos = (void *)tmp_buf;
     tmp_buf += pbytes;
-    tmp_buf += ALIGN(tmp_buf, long);
+    tmp_buf += ALIGN(tmp_buf, size_t);
     for (i = 0; i < tnfa->num_states; i++)
       {
   reach[i].tags = (void *)tmp_buf;

--- a/win32/tre-mem.c
+++ b/win32/tre-mem.c
@@ -143,7 +143,7 @@ tre_mem_alloc_impl(tre_mem_t mem, int provided, void *provided_block,
     }
 
   /* Make sure the next pointer will be aligned. */
-  size += ALIGN(mem->ptr + size, long);
+  size += ALIGN(mem->ptr + size, size_t);
 
   /* Allocate from current block. */
   ptr = mem->ptr;

--- a/win32/tre.h
+++ b/win32/tre.h
@@ -32,6 +32,7 @@
 #include <regex.h>
 #include <wchar.h>
 #include <wctype.h>
+#include <stdint.h>
 
 #undef  TRE_MBSTATE
 
@@ -77,8 +78,8 @@ typedef wctype_t tre_ctype_t;
 /* Returns number of bytes to add to (char *)ptr to make it
    properly aligned for the type. */
 #define ALIGN(ptr, type) \
-  ((((long)ptr) % sizeof(type)) \
-   ? (sizeof(type) - (((long)ptr) % sizeof(type))) \
+  ((((uintptr_t)ptr) % sizeof(type)) \
+   ? (sizeof(type) - (((uintptr_t)ptr) % sizeof(type))) \
    : 0)
 
 #undef MAX


### PR DESCRIPTION
It was brought up in this PR https://github.com/openSUSE/libsolv/pull/436 that `long` is just 32 bit on windows and so I thought this might be necessary.  Please let me know if that's not the case.

EDIT: I also see `long` used here too https://github.com/openSUSE/libsolv/blob/master/win32/regcomp.c#L102-L103 but am more hesitant to change that as I'm not really sure why it's `long` here when `code_min` and `code_max` are defined as `int` here https://github.com/openSUSE/libsolv/blob/master/win32/regcomp.c#L49-L50 and all the usage in `regcomp.c` seem to treat them as `int`