### PR TITLE
Fix memory leaks

### DIFF
--- a/ext/repo_deb.c
+++ b/ext/repo_deb.c
@@ -792,5 +792,6 @@ pool_deb_get_autoinstalled(Pool *pool, FILE *fp, Queue *q, int flags)
 	  break;
 	}
     }
+    solv_free(buf);
 }
 

--- a/ext/testcase.c
+++ b/ext/testcase.c
@@ -1477,11 +1477,11 @@ testcase_solverresult(Solver *solv, int resultflags)
       queue_init(&q);
       for (rid = 1; (rclass = solver_ruleclass(solv, rid)) != SOLVER_RULE_UNKNOWN; rid++)
 	{
-	  char *prefix = solv_dupjoin("rule ", testcase_rclass2str(rclass), " ");
-	  prefix = solv_dupappend(prefix, testcase_ruleid(solv, rid), 0);
 	  solver_ruleliterals(solv, rid, &q);
 	  if (rclass == SOLVER_RULE_FEATURE && q.count == 1 && q.elements[0] == -SYSTEMSOLVABLE)
 	    continue;
+	  char *prefix = solv_dupjoin("rule ", testcase_rclass2str(rclass), " ");
+	  prefix = solv_dupappend(prefix, testcase_ruleid(solv, rid), 0);
 	  for (i = 0; i < q.count; i++)
 	    {
 	      Id p = q.elements[i];


### PR DESCRIPTION
The PR fixes two memory leaks.

Note:
Be honest. The function `pool_deb_get_autoinstalled` seems strange to mee. Is the `while (bufl - l < 1024)` loop dead code?