### PR TITLE
Fix segfault in resolve_jobrules

### DIFF
--- a/src/solver.c
+++ b/src/solver.c
@@ -1629,6 +1629,7 @@ resolve_jobrules(Solver *solv, int level, int disablerules, Queue *dq)
 	}
       olevel = level;
       level = selectandinstall(solv, level, dq, disablerules, i, SOLVER_REASON_RESOLVE_JOB);
+      r = solv->rules + i;    /* selectandinstall may have added more rules */
       if (level <= olevel)
 	{
 	  if (level == olevel)


### PR DESCRIPTION
In the for loop in `resolve_jobrules`, `selectandinstall` is called and sometimes rules are added and a `realloc` is required if there's no more memory available in the allocated block.  `r--` would just decrement the old pointer but the `realloc` could return a completely different block of memory.

Issue this was found in for reference https://github.com/mamba-org/boa/issues/146#issuecomment-809374089