### PR TITLE
Fix: lzopen, zstdopen, zchunkopen

### DIFF
--- a/ext/solv_xfopen.c
+++ b/ext/solv_xfopen.c
@@ -199,7 +199,7 @@ static LZFILE *lzopen(const char *path, const char *mode, int fd, int isxz)
   if (ret != LZMA_OK)
     {
       fclose(fp);
-      free(lzfile);
+      solv_free(lzfile);
       return 0;
     }
   return lzfile;
@@ -232,7 +232,7 @@ static int lzclose(void *cookie)
     }
   lzma_end(&lzfile->strm);
   rc = fclose(lzfile->file);
-  free(lzfile);
+  solv_free(lzfile);
   return rc;
 }
 
@@ -432,7 +432,7 @@ static int zstdclose(void *cookie)
       ZSTD_freeDStream(zstdfile->dstream);
     }
   rc = fclose(zstdfile->file);
-  free(zstdfile);
+  solv_free(zstdfile);
   return rc;
 }
 


### PR DESCRIPTION
- Fix: lzopen and zstdopen: don't close supplied fd
  In the case of a `calloc` memory allocation failure or failure of any of the other functions, the `fp` file stream has been closed.  And the stream closed the associated supplied `fd` file descriptor.
   The caller then closed the closed descriptor again (eg `curlfopen` in `repoinfo_download.c`: `if (!Fp) close (fd);`) -> double_close. In multi threaded software risk of race conditions. Another thread open another file and reuse just closed file descriptor. The caller then closes the file of another thread.

- Fix: zchunkopen: resources leaks, don't close supplied fd
  System variant:
    - resource leaks when `zck_init_read` or `zck_init_write` fails
    - supplied fd will be closed if `zck_create` fails
    
  Libsolv limited zchunk implementation:
   - resource leak when `strcmp(mode, "r") != 0`
   - supplied fd will be closed if `solv_zchunk_open` fails (Fix is thread unsafe. However the original version caused a double-close in the caller function and was thread unsafe too.)

- Fix: lzopen, zstdopen, zchunkopen: Inconsistent file descriptor tests
  Example: The caller passes a valid `path` and an invalid `fd = -2`. It is not caught by the `(!path && fd < 0)` check and the invalid `fd` was used for `fdopen` (because fd != -1) instead of using `path`.

Note:
There are memory allocation inconsistencies in the code. For example, `lzopen` uses` calloc` and `zstdopen` uses` solv_calloc`.
On error: `calloc` returns NULL while` solv_calloc` calls `solv_oom` (` abort`, `exit`). Thus, the behavior of `solv_xfopen` and` solv_xfopen_fd` is different for different types of compression.
In my opinion, the code should be unified. (How does `bzopen` behave in low memory conditions?) 