### PR TITLE
Fix: Memory leaks in SWIG generated code (for Python)

### DIFF
--- a/bindings/solv.i
+++ b/bindings/solv.i
@@ -63,7 +63,7 @@ typedef struct {
   $2 = size;
 }
 
-%typemap(freearg,noblock=1,match="in") (const unsigned char *str, int len) {
+%typemap(freearg,noblock=1,match="in") (const unsigned char *str, size_t len) {
   if (alloc$argnum == SWIG_NEWOBJ) %delete_array(buf$argnum);
 }
 


### PR DESCRIPTION
There were memory leaks in the `Chksum_from_bin`, `Chksum_add`, `SolvFp_write` functions wrapper for Python

The problem was in freearg typemap argument defined in "solv.i". Therefore, the typemap was not applied.