### PR TITLE
improve conda variant handling

### DIFF
--- a/src/conda.c
+++ b/src/conda.c
@@ -134,7 +134,7 @@ solv_vercmp_conda(const char *s1, const char *q1, const char *s2, const char *q2
 		return -1;
 	      if (s1p - s1 > s2p - s2)
 		return 1;
-	      r = s1p - s1 ? strncmp(s1, s2, s1p - s1) : 0;
+	      r = (s1p - s1) ? strncmp(s1, s2, s1p - s1) : 0;
 	      if (r)
 		return r;
 	    }

--- a/src/policy.h
+++ b/src/policy.h
@@ -43,6 +43,9 @@ extern void pool_best_solvables(Pool *pool, Queue *plist, int flags);
 
 /* internal, do not use */
 extern void prune_to_best_version(Pool *pool, Queue *plist);
+#ifdef ENABLE_CONDA
+extern void prune_to_best_version_conda(Pool *pool, Queue *plist);
+#endif
 extern void policy_prefer_favored(Solver *solv, Queue *plist);
 
 

--- a/src/solver.c
+++ b/src/solver.c
@@ -3360,6 +3360,30 @@ setup_favormap(Solver *solv)
     }
 }
 
+static void
+setup_trackfeatures_favor(Solver *solv)
+{
+  Pool *pool = solv->pool;
+  int idx, cnt;
+  Id p;
+
+  solv_free(solv->favormap);
+  solv->favormap = solv_calloc(pool->nsolvables, sizeof(Id));
+
+  idx = 0;
+  FOR_POOL_SOLVABLES(p)
+    {
+      Solvable *s = pool->solvables + p;
+      cnt = solvable_lookup_count(s, SOLVABLE_TRACK_FEATURES);
+      if (cnt != 0)
+        {
+	  idx++;
+	  solv->favormap[p] = -idx;
+	  solv->havedisfavored = 1;
+        }
+    }
+}
+
 /*
  *
  * solve job queue
@@ -4022,7 +4046,10 @@ solver_solve(Solver *solv, Queue *job)
   /* create favormap if we have favor jobs */
   if (hasfavorjob)
     setup_favormap(solv);
-
+#ifdef ENABLE_CONDA
+  else
+   setup_trackfeatures_favor(solv);
+#endif
   /* now create infarch and dup rules */
   if (!solv->noinfarchcheck)
     solver_addinfarchrules(solv, &addedmap);


### PR DESCRIPTION
There are a couple of formatting issues here but I am looking for some early feedback on this PR:

- I am adding a disfavor map entry for those packages that have a track_features count != 0
- I am returning multiple package versions for prune_to_best_version to create multiple solve branches. With conda the package alternatives have the same name, but different build strings. So in a first step the best package is selected, and in a second step the alternatives are added back in. Alternatives need to have the same version and build number as the "best" package (e.g. for scipy pypy and cpython builds):
	- `scipy-1.6.3-py37h29e03ee_0`
	- `scipy-1.6.3-py37ha768fb6_0`

So far this seems to be working quite well. I am just wondering if I am on the right path with this?