### PR TITLE
initial ordering by reldep and reldep-trackfeatures for conda

### DIFF
--- a/src/conda.h
+++ b/src/conda.h
@@ -17,6 +17,7 @@ int pool_evrcmp_conda(const Pool *pool, const char *evr1, const char *evr2, int 
 int solvable_conda_matchversion(Solvable *s, const char *version);
 Id pool_addrelproviders_conda(Pool *pool, Id name, Id evr, Queue *plist);
 Id pool_conda_matchspec(Pool *pool, const char *name);
+int conda_compare_bounds(const char* b1, const char* b2);
 
 #endif /* LIBSOLV_CONDA_H */
 

--- a/src/policy.h
+++ b/src/policy.h
@@ -45,6 +45,9 @@ extern void pool_best_solvables(Pool *pool, Queue *plist, int flags);
 extern void prune_to_best_version(Pool *pool, Queue *plist);
 extern void policy_prefer_favored(Solver *solv, Queue *plist);
 
+#ifdef ENABLE_CONDA
+extern void prune_to_best_version_conda(Pool *pool, Queue *plist);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR adds additional layers of ordering for variants (packages with the same name, version & build number):


- it inspects the dependencies and tries to figure out lower- and upper bounds for the reldep specifier and sort by lower bound so that the variant package with `python >=3.8,<3.9` is sorted higher than `python >=3.6,<3.7` etc.
- it inspects the first level dependencies to check if "all selected" dependencies have a "track_feature" which would de-prioritize that variant package

I still need to improve the lower- and upper bound finding and comparison, but in my initial tests this code performs reasonably well. 

Another corner case is when we have the same reldep more than once, e.g. packages could have python dependency twice:

```
- python >=3.6,<3.7
- python
```

Which will further complicate the code.