### PR TITLE
Store conda packages signatures and signed metadata

### DIFF
--- a/ext/solv_jsonparser.h
+++ b/ext/solv_jsonparser.h
@@ -45,5 +45,6 @@ void jsonparser_init(struct solv_jsonparser *jp, FILE *fp);
 void jsonparser_free(struct solv_jsonparser *jp);
 int jsonparser_parse(struct solv_jsonparser *jp);
 int jsonparser_skip(struct solv_jsonparser *jp, int type);
+int jsonparser_as_str(struct solv_jsonparser *jp, int type, int dequeue);
 
 #endif /* SOLV_JSONPARSER_H */


### PR DESCRIPTION
Description
---

- Store packages signatures
- Store packages extra metadata to allow later signature verification
  - those metadata are also signed
  - without storing metadata, we need to re-open and parse the `repodata.json` file
- Remove rounding of the timestamp, causing failing verification against original `repodata.json` file
  - another solution would be to have a signature process with that rounding step
  - it looks like introducing complexity
  - is this required for full features parity with `conda`? is there any case where 2 different builds differ from some milliseconds and should be considered equivalent?

cc @wolfv 
