### PR TITLE
Add an ifdef allowing to rename conflicting Solvable::requires

### DIFF
--- a/src/solvable.h
+++ b/src/solvable.h
@@ -34,6 +34,19 @@ typedef struct s_Solvable {
   struct s_Repo *repo;		/* repo we belong to */
 
   /* dependencies are offsets into repo->idarraydata */
+  /* the ifdef resolves "requires" conflicting with a C++20 keyword */
+#ifdef LIBSOLV_SOLVABLE_PREPEND_DEP
+  Offset dep_provides;		/* terminated with Id 0 */
+  Offset dep_obsoletes;
+  Offset dep_conflicts;
+
+  Offset dep_requires;
+  Offset dep_recommends;
+  Offset dep_suggests;
+
+  Offset dep_supplements;
+  Offset dep_enhances;
+#else
   Offset provides;		/* terminated with Id 0 */
   Offset obsoletes;
   Offset conflicts;
@@ -44,7 +57,7 @@ typedef struct s_Solvable {
 
   Offset supplements;
   Offset enhances;
-
+#endif
 } Solvable;
 
 /* lookup functions */


### PR DESCRIPTION
In C++20 requires is a new keyword, causing a conflict with the
Solvable::requires attribute. From the outside this can only be fixed
with an ugly preprocessor redefinition of the symbol around each libsolv
header include.

This commit adds an #ifdef allowing to rename the attribute in case
C++20 or higher is used, which can be easily defined in one place in the
libolv user's build system.

I am willing to resolve this in any other way if you have a better idea, as well as bikeshed on the new name for the attribute :slightly_smiling_face:.