### PR TITLE
Fix segfault on conflict resolution when using bindings

### DIFF
--- a/bindings/solv.i
+++ b/bindings/solv.i
@@ -3411,7 +3411,7 @@ returnself(matchsolvable)
     e = solv_calloc(1, sizeof(*e));
     e->solv = solv;
     e->problemid = problemid;
-    e->solutionid = id;
+    e->solutionid = solutionid;
     e->id = id;
     e->type = type;
     e->p = p;


### PR DESCRIPTION
Solutionelement objects were created with a wrong solutionid (i.e. the
solution element id was used for the solutionid field). This led to invalid
array indexes when trying to read the extraflags which then escalated
into a segfault. Fix by setting solutionid correctly in the Solutionelement
constructor.