### PR TITLE
split rules number printing into seperate statements

### DIFF
--- a/src/solver.c
+++ b/src/solver.c
@@ -4149,8 +4149,7 @@ solver_solve(Solver *solv, Queue *job)
   map_free(&installcandidatemap);
   queue_free(&q);
 
-  POOL_DEBUG(SOLV_DEBUG_STATS, "%d pkg rules, 2 * %d update rules, %d job rules, %d infarch rules, %d dup rules, %d choice rules, %d best rules, %d yumobs rules\n"
-  "%d black rules, %d recommends rules, %d repo priority rules\n",
+  POOL_DEBUG(SOLV_DEBUG_STATS, "%d pkg rules, 2 * %d update rules, %d job rules, %d infarch rules, %d dup rules, %d choice rules, %d best rules, %d yumobs rules\n",
    solv->pkgrules_end - 1, 
    solv->updaterules_end - solv->updaterules, 
    solv->jobrules_end - solv->jobrules, 
@@ -4158,7 +4157,8 @@ solver_solve(Solver *solv, Queue *job)
    solv->duprules_end - solv->duprules, 
    solv->choicerules_end - solv->choicerules, 
    solv->bestrules_end - solv->bestrules, 
-   solv->yumobsrules_end - solv->yumobsrules,
+   solv->yumobsrules_end - solv->yumobsrules);
+  POOL_DEBUG(SOLV_DEBUG_STATS, "%d black rules, %d recommends rules, %d repo priority rules\n"
    solv->blackrules_end - solv->blackrules,
    solv->recommendsrules_end - solv->recommendsrules,
    solv->strictrepopriorules_end - solv->strictrepopriorules);


### PR DESCRIPTION
This is a tiny nitpick to get two different debug callbacks. We're using `spdlog` to print the logs now and this makes everything nicely aligned.