### PR TITLE
Fix memory leak when using testsolv to execute cases

### DIFF
--- a/ext/testcase.c
+++ b/ext/testcase.c
@@ -2448,7 +2448,10 @@ testcase_read(Pool *pool, FILE *fp, const char *testcase, Queue *job, char **res
 		}
 	    }
 	  if (resultp)
+	  {
+	    solv_free(*resultp);
 	    *resultp = result;
+	  }
 	  else
 	    solv_free(result);
 	  if (resultflagsp)


### PR DESCRIPTION
*resultp will only keep the pointer of the last cycle, which will lead to memory leakage.
This solves the first memory leak problem in issue #496 "==255147==error..."