### PR TITLE
Ensure duplinvolvedmap_all is reset when a solver is reused

### DIFF
--- a/src/solver.c
+++ b/src/solver.c
@@ -3533,6 +3533,7 @@ solver_solve(Solver *solv, Queue *job)
   map_zerosize(&solv->bestupdatemap);
   solv->fixmap_all = 0;
   map_zerosize(&solv->fixmap);
+  solv->dupinvolvedmap_all = 0;
   map_zerosize(&solv->dupmap);
   map_zerosize(&solv->dupinvolvedmap);
   solv->process_orphans = 0;


### PR DESCRIPTION
Otherwise, if solver is used with a SOLVER_DISTUPGRADE job, then reused
without one, this will cause solver_addduprules() to be called, even
though needduprules is 0, which will crash trying to dereference
solv->dupmap, which is NULL because solver_createdupmaps() hasn't been
called.