### PR TITLE
fix memory leak caused by commit 1da9bef8

### DIFF
--- a/src/rules.c
+++ b/src/rules.c
@@ -3607,6 +3607,7 @@ solver_disablechoicerules(Solver *solv, Rule *r)
       if (p)
 	solver_disablerule(solv, r);
     }
+  map_free(&m);
 }
 
 static void


### PR DESCRIPTION
the memory allocated by map_init in solver_disablechoicerules failed to be released in time.#511