### PR TITLE
Python: Remove usage of the deprecated distutils module

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -13,7 +13,7 @@ ELSE()
 ENDIF()
 FIND_PACKAGE (PythonInterp ${python_version} REQUIRED)
 
-EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib(True))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
+EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; import sysconfig; stdout.write(sysconfig.get_path('platlib'))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
 
 IF (NOT DEFINED PYTHON_VERSION_MAJOR)
     SET (PYTHON_VERSION_MAJOR 2)

--- a/bindings/python3/CMakeLists.txt
+++ b/bindings/python3/CMakeLists.txt
@@ -10,8 +10,8 @@ IF (NOT DEFINED PYTHON3_EXECUTABLE)
 SET (PYTHON3_EXECUTABLE "/usr/bin/python3")
 ENDIF (NOT DEFINED PYTHON3_EXECUTABLE)
 
-EXECUTE_PROCESS(COMMAND ${PYTHON3_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib(True))" OUTPUT_VARIABLE PYTHON3_INSTALL_DIR)
-EXECUTE_PROCESS(COMMAND ${PYTHON3_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_inc())" OUTPUT_VARIABLE PYTHON3_INCLUDE_DIR)
+EXECUTE_PROCESS(COMMAND ${PYTHON3_EXECUTABLE} -c "from sys import stdout; import sysconfig; stdout.write(sysconfig.get_path('platlib'))" OUTPUT_VARIABLE PYTHON3_INSTALL_DIR)
+EXECUTE_PROCESS(COMMAND ${PYTHON3_EXECUTABLE} -c "from sys import stdout; import sysconfig; stdout.write(sysconfig.get_path('include'))" OUTPUT_VARIABLE PYTHON3_INCLUDE_DIR)
 
 SET (SWIG_PY3_FLAGS -DPYTHON3=1)
 SET (SWIG_PY3_FLAGS ${SWIG_PY3_FLAGS} -DSWIG_PYTHON_LEGACY_BOOL=1)

--- a/package/libsolv.spec.in
+++ b/package/libsolv.spec.in
@@ -90,13 +90,13 @@ BuildRequires:  swig
 %endif
 
 %if %{with python}
-%global python_sitearch %(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(True))")
+%global python_sitearch %(python -c "from sysconfig import get_path; print(get_path('platlib'))")
 BuildRequires:  python-devel
 BuildRequires:  swig
 %endif
 
 %if %{with python3}
-%global python3_sitearch %(python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(True))")
+%global python3_sitearch %(python3 -c "from sysconfig import get_path; print(get_path('platlib'))")
 BuildRequires:  python3-devel
 BuildRequires:  swig
 %endif


### PR DESCRIPTION
Python 3.12+ no longer has distutils.

See https://peps.python.org/pep-0632/