### PR TITLE
Fix build without C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-PROJECT (libsolv)
+PROJECT (libsolv C)
 
 CMAKE_MINIMUM_REQUIRED (VERSION 2.8.5)
 

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -103,6 +103,7 @@ IF (ENABLE_CUDFREPO)
 ENDIF (ENABLE_CUDFREPO)
 
 IF (ENABLE_HAIKU)
+    enable_language(CXX)
     SET (libsolvext_SRCS ${libsolvext_SRCS}
 	repo_haiku.cpp)
     SET (libsolvext_HEADERS ${libsolvext_HEADERS}


### PR DESCRIPTION
Fix the following build failure without C++:

```
CMake Error at CMakeLists.txt:1 (PROJECT):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```

Fixes:
 - http://autobuild.buildroot.org/results/a7f2176d40f156c319754ef5d3b7fd0decfe754f

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>