### PR TITLE
Fix conda headers

### DIFF
--- a/ext/repo_conda.h
+++ b/ext/repo_conda.h
@@ -5,7 +5,24 @@
  * for further information
  */
 
+#ifndef LIBSOLV_REPO_CONDA_H
+#define LIBSOLV_REPO_CONDA_H
+
+#include <stdio.h>
+
+#include "repo.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define CONDA_ADD_USE_ONLY_TAR_BZ2	(1 << 8)
 #define CONDA_ADD_WITH_SIGNATUREDATA	(1 << 9)
 
 extern int repo_add_conda(Repo *repo, FILE *fp, int flags);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBSOLV_REPO_CONDA_H */

--- a/src/conda.h
+++ b/src/conda.h
@@ -13,10 +13,21 @@
 #ifndef LIBSOLV_CONDA_H
 #define LIBSOLV_CONDA_H
 
+#include "pooltypes.h"
+#include "solvable.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int pool_evrcmp_conda(const Pool *pool, const char *evr1, const char *evr2, int mode);
 int solvable_conda_matchversion(Solvable *s, const char *version);
 Id pool_addrelproviders_conda(Pool *pool, Id name, Id evr, Queue *plist);
 Id pool_conda_matchspec(Pool *pool, const char *name);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LIBSOLV_CONDA_H */
 

--- a/src/pooltypes.h
+++ b/src/pooltypes.h
@@ -13,6 +13,10 @@
 #ifndef LIBSOLV_POOLTYPES_H
 #define LIBSOLV_POOLTYPES_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* format version number for .solv files */
 #define SOLV_VERSION_0 0
 #define SOLV_VERSION_1 1
@@ -41,5 +45,9 @@ typedef int Id;		/* must be signed!, since negative Id is used in solver rules t
 
 /* offset value, e.g. used to 'point' into the stringspace */
 typedef unsigned int Offset;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LIBSOLV_POOLTYPES_H */


### PR DESCRIPTION
Some fix to be able to include headers independently and without `extern "C"`.