### PR TITLE
addfileprovides_queue: return an array containing all added provides

### DIFF
--- a/doc/libsolv-bindings.txt
+++ b/doc/libsolv-bindings.txt
@@ -474,7 +474,7 @@ repositories. This method will scan all dependency for file names and then scan
 all packages for matching files. If a filename has been matched, it will be
 added to the provides list of the corresponding package. The
 addfileprovides_queue variant works the same way but returns an array
-containing all file dependencies. This information can be stored in the
+containing all added file provides. This information can be stored in the
 meta section of the repositories to speed up the next time the
 repository is loaded and addfileprovides is called.
 


### PR DESCRIPTION
The queues returned can be stored in repository meta section REPOSITORY_ADDEDFILEPROVIDES:
https://github.com/openSUSE/libsolv/blob/master/examples/solv/fileprovides.c#L73

Storing file dependencies can lead to problems:
- first load metadata without filelists
- call pool_addfileprovides_queue(...)
- and store queues in REPOSITORY_ADDEDFILEPROVIDES then on the next run filelists are loaded but during adding fileprovides none are added because stored file dependecies match required file dependencies.

This can be solved by returning added file provides instead. This also matches with the REPOSITORY_ADDEDFILEPROVIDES name.

This is changing API.
I am not sure if it is a good solution to the problem.