### PR TITLE
bindings: Fix building with Python 3.13

### DIFF
--- a/bindings/solv.i
+++ b/bindings/solv.i
@@ -1729,7 +1729,7 @@ returnself(matchsolvable)
   SWIGINTERN int loadcallback(Pool *pool, Repodata *data, void *d) {
     XRepodata *xd = new_XRepodata(data->repo, data->repodataid);
     PyObject *args = Py_BuildValue("(O)", SWIG_NewPointerObj(SWIG_as_voidptr(xd), SWIGTYPE_p_XRepodata, SWIG_POINTER_OWN | 0));
-    PyObject *result = PyEval_CallObject((PyObject *)d, args);
+    PyObject *result = PyObject_Call((PyObject *)d, args, NULL);
     int ecode = 0;
     int vresult = 0;
     Py_DECREF(args);


### PR DESCRIPTION
Use `PyObject_Call` instead of the deprecated `PyEval_CallObject` as this function is to be removed in Python 3.13.

See https://docs.python.org/3.13/whatsnew/3.13.html#id11.

Currently, libsolv fails to build with Python 3.13.0a1.

```
/builddir/build/BUILD/libsolv-0.7.25/redhat-linux-build/bindings/python/solv_python.c:4734:24: error: implicit declaration of function ‘PyEval_CallObject’; did you mean ‘PyObject_CallObject’? [-Werror=implicit-function-declaration]
 4734 |     PyObject *result = PyEval_CallObject((PyObject *)d, args);
      |                        ^~~~~~~~~~~~~~~~~
      |                        PyObject_CallObject
```