### PR TITLE
Fix a couple small static analysis findings for uninitialized structs

### DIFF
--- a/ext/repo_rpmmd.c
+++ b/ext/repo_rpmmd.c
@@ -609,6 +609,8 @@ fill_cshash_from_new_solvables(struct parsedata *pd)
   KeyValue kv;
   Repokey *key;
 
+  memset(&kv, 0, sizeof(kv));
+
   for (i = pd->first; i < pool->nsolvables; i++)
     {
       if (pool->solvables[i].repo != pd->repo)

--- a/ext/repo_susetags.c
+++ b/ext/repo_susetags.c
@@ -339,6 +339,7 @@ lookup_shared_id(Repodata *data, Id p, Id keyname, Id voidid, int uninternalized
   if (uninternalized)
     {
       KeyValue kv;
+      memset(&kv, 0, sizeof(kv));
       Repokey *key = repodata_lookup_kv_uninternalized(data, p, keyname, &kv);
       if (!key)
         return 0;

--- a/ext/testcase.c
+++ b/ext/testcase.c
@@ -1497,6 +1497,7 @@ testcase_solverresult(Solver *solv, int resultflags)
   if ((resultflags & TESTCASE_RESULT_USERINSTALLED) != 0)
     {
       Queue q;
+      queue_init(&q);
       solver_get_userinstalled(solv, &q, 0);
       for (i = 0; i < q.count; i++)
 	{


### PR DESCRIPTION
The memset() on the KeyValue is more explicit even though if you trace the code you will see it fills out the struct.  However, it's possible that not every struct member will be initialized and adding the memset() makes things more obvious and appeases the static analyzer.

The queue_init() appeared to just be missing.