### PR TITLE
package: Enable shared library for all platforms but SLE < 16

### DIFF
--- a/package/libsolv.spec.in
+++ b/package/libsolv.spec.in
@@ -60,8 +60,13 @@
 %bcond_with ruby
 %bcond_with perl
 %endif
+%if 0%{?suse_version} && 0%{?suse_version} < 1600
 %bcond_without static
 %bcond_with shared
+%else
+%bcond_with static
+%bcond_without shared
+%endif
 %bcond_with zypp
 
 Name:           libsolv


### PR DESCRIPTION
This simplifies things for interfacing with the library and ensures that when libsolv is updated that package managers get the correct functionality.

This also allows us to drop the hacks to deal with static libsolv for DNF in SUSE distributions.