### PR TITLE
Add a Conflicts in libsolv-tools-base

### DIFF
--- a/package/libsolv.spec.in
+++ b/package/libsolv.spec.in
@@ -171,6 +171,7 @@ reading repositories.
 Summary:        Utilities used by libzypp to manage .solv files
 Group:          System/Management
 Provides:       libsolv-tools:%{_bindir}/repo2solv
+Conflicts:      libsolv-tools < 0.7.29
 
 %description tools-base
 This subpackage contains utilities used by libzypp to manage solv files.


### PR DESCRIPTION
Add a Conflicts in `libsolv-tools-base`
so this does not get installed in parallel with older versions of `libsolv-tools`