### PR TITLE
Provide a symbol specific for the ruby-version

### DIFF
--- a/package/libsolv.changes
+++ b/package/libsolv.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan 15 09:16:51 UTC 2025 - Bernhard Wiedemann <bwiedemann@suse.com>
+
+- Provide a symbol specific for the ruby-version
+  so yast does not break across updates (boo#1235598)
+
+-------------------------------------------------------------------
 Tue Nov 12 10:54:33 CET 2024 - mls@suse.de
 
 - fix replaces_installed_package using the wrong solvable id

--- a/package/libsolv.spec.in
+++ b/package/libsolv.spec.in
@@ -208,6 +208,9 @@ Applications demoing the libsolv library.
 %package -n ruby-solv
 Summary:        Ruby bindings for the libsolv library
 Group:          Development/Languages/Ruby
+%if 0%{?suse_version}
+Provides:       ruby-solv-ruby-%{rb_ver}
+%endif
 
 %description -n ruby-solv
 Ruby bindings for libsolv.


### PR DESCRIPTION
Provide a symbol specific for the ruby-version
so that yast does not break across updates (boo#1235598)