### PR TITLE
Fix building in ISO C23

### DIFF
--- a/bindings/solv.i
+++ b/bindings/solv.i
@@ -976,7 +976,9 @@ SWIG_AsValDepId(void *obj, int *val) {
 
 /* argh, swig undefs bool for perl */
 #ifndef bool
+#if !defined __STDC_VERSION__ || __STDC_VERSION__ < 202311L
 typedef int bool;
+#endif
 #endif
 
 #include "pool.h"


### PR DESCRIPTION
ISO C23 added bool type as a keyword. It is the standard GCC 15 uses by default and compilation of bindings/perl/solv_perl.c fails then:

    bindings/perl/solv_perl.c:1641:13: error: ‘bool’ cannot be defined via ‘typedef’
     1641 | typedef int bool;
	  |             ^~~~
    /home/test/fedora/libsolv/libsolv-0.7.31-build/libsolv-0.7.31/redhat-linux-build/bindings/perl/solv_perl.c:1641:13: note: ‘bool’ is a keyword with ‘-std=c23’ onwards
    /home/test/fedora/libsolv/libsolv-0.7.31-build/libsolv-0.7.31/redhat-linux-build/bindings/perl/solv_perl.c:1641:1: warning: useless type name in empty declaration
     1641 | typedef int bool;
	  | ^~~~~~~

The typedef comes from bindings/solv.i which attemps to supply it in case Swig undefines it.

This patch fixes it by not defining it in case ISO C23 or newer is in use. Keywords cannot be checked by a preprocessor, neither undefined (by Swig).

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2340762