### PR TITLE
Increase CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-PROJECT (libsolv C)
+CMAKE_MINIMUM_REQUIRED (VERSION 3.5)
 
-CMAKE_MINIMUM_REQUIRED (VERSION 2.8.5)
+PROJECT (libsolv C)
 
 OPTION (ENABLE_STATIC "Build a static version of the libraries?" OFF)
 OPTION (DISABLE_SHARED "Do not build a shared version of the libraries?" OFF)

--- a/package/libsolv.spec.in
+++ b/package/libsolv.spec.in
@@ -72,7 +72,7 @@ License:        BSD-3-Clause
 Group:          Development/Libraries/C and C++
 URL:            https://github.com/openSUSE/libsolv
 Source:         libsolv-%{version}.tar.bz2
-BuildRequires:  cmake
+BuildRequires:  cmake >= 3.5
 BuildRequires:  gcc-c++
 BuildRequires:  libxml2-devel
 BuildRequires:  rpm-devel


### PR DESCRIPTION
CMake 4.0.0 removed a support for CMake scripts older than 3.5 and a build with CMake 4.0.0-rc2 fails like this:

    $ /usr/bin/cmake -S . -B redhat-linux-build
    CMake Warning (dev) at CMakeLists.txt:1 (PROJECT):
      cmake_minimum_required() should be called prior to this top-level project()
      call.  Please see the cmake-commands(7) manual for usage documentation of
      both commands.
    This warning is for project developers.  Use -Wno-dev to suppress it.

    CMake Error at CMakeLists.txt:3 (CMAKE_MINIMUM_REQUIRED):
      Compatibility with CMake < 3.5 has been removed from CMake.

      Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
      to tell CMake that the project requires at least <min> but has been updated
      to work with policies introduced by <max> or earlier.

      Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

    -- Configuring incomplete, errors occurred!

There seems to be no way of making the script working with all versions. CMake 3.5 was relased in 2016.

This patch increases the minimal version to 3.5 and moves it to the top of the script as it needs to be the very first thing of a script as recommeded by cmake:

    CMake Warning (dev) at CMakeLists.txt:1 (PROJECT):
      cmake_minimum_required() should be called prior to this top-level project()
      call.  Please see the cmake-commands(7) manual for usage documentation of
      both commands.

I did not set a supported upper version of CMake since I guess we do not want to update it with every new minor CMake release.

Other printed CMake warnings are not news are not addressed with this patch.