### PR TITLE
decision.c: void function should not return anything

### DIFF
--- a/src/decision.c
+++ b/src/decision.c
@@ -737,7 +737,10 @@ solver_get_decisionlist(Solver *solv, Id id, int flags, Queue *decisionlistq)
   Pool *pool = solv->pool;
   Map dm;
   if ((flags & SOLVER_DECISIONLIST_TYPEMASK) != SOLVER_DECISIONLIST_SOLVABLE)
-    return solver_get_proof(solv, id, flags, decisionlistq);
+  {
+    solver_get_proof(solv, id, flags, decisionlistq);
+    return;
+  }
   map_init(&dm, pool->nsolvables);
   MAPSET(&dm, id);
   getdecisionlist(solv, &dm, flags, decisionlistq);


### PR DESCRIPTION
Do not call to solver_get_proof as part of return statement

Found by GCC ("ISO C forbids ‘return’ with expression, in function returning void", pedantic).