### PR TITLE
Add includes for getopt() and strcasecmp()

### DIFF
--- a/src/chksum.c
+++ b/src/chksum.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <unistd.h>
 
 #include "pool.h"

--- a/tools/repo2solv.c
+++ b/tools/repo2solv.c
@@ -5,6 +5,7 @@
  * for further information
  */
 
+#include <getopt.h>
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Found by GCC in C23 mode (implicit-function-declaration).