### PR TITLE
Fix build on win32 & mingw.

### DIFF
--- a/ext/solv_xfopen.h
+++ b/ext/solv_xfopen.h
@@ -10,7 +10,7 @@
 
 #include <stddef.h>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
   #include <BaseTsd.h>
   typedef SSIZE_T ssize_t;
 #else

--- a/src/repo_write.c
+++ b/src/repo_write.c
@@ -188,7 +188,7 @@ write_compressed_blob(Repodata *data, void *blob, int len)
 	  write_u8(data, clen);
 	  write_blob(data, cpage, clen);
 	}
-      blob += chunk;
+      blob = (char*)blob + chunk;
       len -= chunk;
     }
 }


### PR DESCRIPTION
 - Issue 1, like: https://github.com/eclipse-cyclonedds/cyclonedds/issues/2051
 - Issue 2, msvc does not allow pointer arithmetic on `void*`
