### PR TITLE
Remove superfluous cast of NULL pointer

### DIFF
--- a/ext/solv_xfopen.c
+++ b/ext/solv_xfopen.c
@@ -33,7 +33,7 @@ FILE *solv_cookieopen(void *cookie, const char *mode,
   return funopen(cookie,
       (int (*)(void *, char *, int))(*mode == 'r' ? cread : NULL),		/* readfn */
       (int (*)(void *, const char *, int))(*mode == 'w' ? cwrite : NULL),	/* writefn */
-      (fpos_t (*)(void *, fpos_t, int))NULL,					/* seekfn */
+      NULL,									/* seekfn */
       cclose
       );
 #elif defined(HAVE_FOPENCOOKIE)


### PR DESCRIPTION
NetBSD (and OpenBSD) actually use off_t instead of fpos_t here, so the cast introduces an unnecessary diagnostic when compiling on NetBSD.

NetBSD man page: [funopen.3](https://man.netbsd.org/NetBSD-10.1/funopen.3)
OpenBSD man page: [funopen.3](https://man.openbsd.org/funopen.3)
FreeBSD man page: [funopen.3](https://man.freebsd.org/cgi/man.cgi?query=funopen&sektion=3&manpath=FreeBSD+15.0-RELEASE&arch=default&format=html)