### PR TITLE
repo_mdk: fix @recommends@ tag offset

### DIFF
--- a/ext/repo_mdk.c
+++ b/ext/repo_mdk.c
@@ -124,7 +124,7 @@ repo_add_mdk(Repo *repo, FILE *fp, int flags)
       else if (!strncmp(buf + 1, "requires@", 9))
 	s->requires = parse_deps(s, buf + 10, SOLVABLE_PREREQMARKER);
       else if (!strncmp(buf + 1, "recommends@", 11))
-	s->recommends = parse_deps(s, buf + 10, 0);
+	s->recommends = parse_deps(s, buf + 12, 0);
       else if (!strncmp(buf + 1, "suggests@", 9))
 	s->suggests = parse_deps(s, buf + 10, 0);
       else if (!strncmp(buf + 1, "obsoletes@", 10))


### PR DESCRIPTION
Found while studying the parser for Mageia.

The dispatcher passed buf + 10 to parse_deps(), but "@recommends@" is 12 characters long. parse_deps() therefore started reading two bytes early, inside the tag itself:
```
  @recommends@libfoo >= 1.0@libbar
            ^^
            buf + 10 points here, buf + @tag size is 12, not 10
```
Because parse_deps() splits on '@', the leading "s@" produced an extra phantom dependency named "s" prepended to every recommends list.

The patch simply fixes the offset to buf + 12 to match the tag length, aligning with every other branch in the dispatcher.

The bug has been dormant because genhdlist2, the synthesis generator used by Mageia today, does not emit @recommends@ lines -- so the phantom dep never reached any solver. 

It probably dates from the commit that first added recommends support
to the mdk backend.