### PR TITLE
[ci] Update GitHub Action checkout from v4 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup
         run:  |
           sudo apt-get install cmake liblzma-dev


### PR DESCRIPTION
Fix deprecation warning that Node20.js will stop working in June.