### PR TITLE
Fix a buffer overflow when copying SHA-384/512 checksum from a Debian repository

### DIFF
--- a/ext/repo_deb.c
+++ b/ext/repo_deb.c
@@ -368,7 +368,7 @@ control2solvable(Solvable *s, Repodata *data, char *control)
   char *p, *q, *end, *tag;
   int x, l;
   int havesource = 0;
-  char checksum[32 * 2 + 1];
+  char checksum[64 * 2 + 1];
   Id checksumtype = 0;
   Id newtype;
 


### PR DESCRIPTION
When parsing Debian repository, control2solvable() copies a package checksum string from the repository into a stack-allocated "char checksum[32 * 2 + 1]" array.

If the repository defined a SHA384 or SHA512 tag, a buffer overflow occured (as can be seen when compiling libsolv with CFLAGS='-O0 -g -fsanitize=address') because those tag values are longer:

    $ cat /tmp/Packages
    Package: p
    Version: 1
    Architecture: all
    SHA512: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000

    $ /tmp/b/tools/deb2solv -r /tmp/Packages
    =================================================================
    ==3695==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7b685ecf0071 at pc 0x7f6861683722 b
    p 0x7fff37e3e7a0 sp 0x7fff37e3df60
    WRITE of size 129 at 0x7b685ecf0071 thread T0
        #0 0x7f6861683721 in strcpy.part.0 (/lib64/libasan.so.8+0x83721) (BuildId: 80bfc4ae44fdec6ef5fecfb01e2b57d28660991c)
        #1 0x7f6861d7f34d in control2solvable /home/test/libsolv/ext/repo_deb.c:491
        #2 0x7f6861d804ea in repo_add_debpackages /home/test/libsolv/ext/repo_deb.c:622
        #3 0x000000400fd5 in main /home/test/libsolv/tools/deb2solv.c:134
        #4 0x7f686123c680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: c04494d63bca865bedf571a4075ef8867ccf9fa9)
        #5 0x7f686123c797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: c04494d63bca865bedf571a4075ef8867ccf9fa9)
        #6 0x000000400694 in _start (/tmp/b/tools/deb2solv+0x400694) (BuildId: a3350337819a51edd0c75293970d3458b5033bc9)

    Address 0x7b685ecf0071 is located in stack of thread T0 at offset 113 in frame
        #0 0x7f6861d7de2a in control2solvable /home/test/libsolv/ext/repo_deb.c:365

      This frame has 1 object(s):
        [48, 113) 'checksum' (line 371) <== Memory access at offset 113 overflows this variable

This patch fixes it by enlarging the buffer to accomodate the longest supported digest string.

This flaw was introduced with c8164bfecf2ba8bcf4c24329534d3104f19da73c commit ("[ABI BREAKAGE] add support for SHA224/384/512").

Reported by Aisle Research.