### PR TITLE
examples/pysolv: switch shebang to python3

### DIFF
--- a/examples/pysolv
+++ b/examples/pysolv
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 #
 # Copyright (c) 2011, Novell Inc.


### PR DESCRIPTION
The example script has been ported to python3 long ago, but the shebang still points to python, which doesn't exist anymore in Ubuntu/Debian and others.