### PR TITLE
Fix const correctness warnings

### DIFF
--- a/ext/solv_xfopen.c
+++ b/ext/solv_xfopen.c
@@ -658,7 +658,7 @@ static inline FILE *myzchunkfdopen(int fd, const char *mode)
 FILE *
 solv_xfopen(const char *fn, const char *mode)
 {
-  char *suf;
+  const char *suf;
 
   if (!fn)
     {
@@ -732,7 +732,7 @@ FILE *
 solv_xfopen_fd(const char *fn, int fd, const char *mode)
 {
   const char *simplemode = mode;
-  char *suf;
+  const char *suf;
 
   suf = fn ? strrchr(fn, '.') : 0;
   if (!mode)

--- a/src/selection.c
+++ b/src/selection.c
@@ -900,14 +900,19 @@ selection_name_arch_rel(Pool *pool, Queue *selection, const char *name, int flag
 {
   int ret, rflags = 0, noprune;
   char *r = 0, *rname = 0;
+  const char *relop;
 
   /* try to split off an relation part */
   if ((flags & SELECTION_REL) != 0)
     {
-      if ((r = strpbrk(name, "<=>")) != 0)
+      if ((relop = (char *)strpbrk(name, "<=>")) == 0)
+        {
+          r = 0;
+        }
+      else
 	{
 	  rname = solv_strdup(name);
-	  r = rname + (r - name);
+	  r = rname + (relop - name);
 	  if ((r = splitrel(rname, r, &rflags)) == 0)
 	    rname = solv_free(rname);
 	}
@@ -1145,6 +1150,7 @@ static int
 selection_canon(Pool *pool, Queue *selection, const char *name, int flags)
 {
   char *rname, *r, *r2;
+  const char *delimiter;
   Id archid = 0;
   int ret;
 
@@ -1172,10 +1178,10 @@ selection_canon(Pool *pool, Queue *selection, const char *name, int flags)
 #endif
   if (pool->disttype == DISTTYPE_DEB)
     {
-      if ((r = strchr(name, '_')) == 0)
+      if ((delimiter = strchr(name, '_')) == 0)
 	return 0;
       rname = solv_strdup(name);	/* so we can modify it */
-      r = rname + (r - name);
+      r = rname + (delimiter - name);
       *r++ = 0;
       if ((ret = selection_name(pool, selection, rname, flags)) == 0)
 	{
@@ -1195,10 +1201,10 @@ selection_canon(Pool *pool, Queue *selection, const char *name, int flags)
 
   if (pool->disttype == DISTTYPE_HAIKU)
     {
-      if ((r = strchr(name, '-')) == 0)
+      if ((delimiter = strchr(name, '-')) == 0)
 	return 0;
       rname = solv_strdup(name);	/* so we can modify it */
-      r = rname + (r - name);
+      r = rname + (delimiter - name);
       *r++ = 0;
       if ((ret = selection_name(pool, selection, rname, flags)) == 0)
 	{
@@ -1216,10 +1222,10 @@ selection_canon(Pool *pool, Queue *selection, const char *name, int flags)
       return selection->count ? ret | SELECTION_CANON : 0;
     }
 
-  if ((r = strrchr(name, '-')) == 0)
+  if ((delimiter = strrchr(name, '-')) == 0)
     return 0;
   rname = solv_strdup(name);	/* so we can modify it */
-  r = rname + (r - name);
+  r = rname + (delimiter - name);
   *r = 0;
 
   /* split off potential arch part from version */

--- a/src/suse.c
+++ b/src/suse.c
@@ -107,7 +107,7 @@ repo_fix_supplements(Repo *repo, Offset provides, Offset supplements, Offset fre
   Pool *pool = repo->pool;
   Id id, idp, idl;
   char buf[1024], *p, *bp;
-  const char *dep;
+  const char *dep, *colon;
   int i, l;
 
   if (provides)
@@ -163,10 +163,10 @@ repo_fix_supplements(Repo *repo, Offset provides, Offset supplements, Offset fre
 	      if (id)
 		supplements = repo_addid_dep(repo, supplements, id, 0);
 	    }
-	  else if ((p = strchr(dep, ':')) != 0 && p != dep && p[1] == '/' && strlen(dep) < sizeof(buf))
+	  else if ((colon = strchr(dep, ':')) != 0 && colon != dep && colon[1] == '/' && strlen(dep) < sizeof(buf))
 	    {
 	      strcpy(buf, dep);
-	      p = buf + (p - dep);
+	      p = buf + (colon - dep);
 	      *p++ = 0;
 	      idp = pool_str2id(pool, buf, 1);
 	      /* strip trailing slashes */


### PR DESCRIPTION
Glibc 2.43 implements C23 const-preserving string-search functions <https://sourceware.org/glibc/wiki/Release/2.43#C23_Const-Preserving_Standard_Library_Macros_May_Break_Some_Packages>.

Building libsolv with that glibc and GCC which defaults to C23 language (since GCC 15) prints these warnings:

    /home/test/libsolv/src/selection.c: In function ‘selection_name_arch_rel’:
    /home/test/libsolv/src/selection.c:907:14: warning: assignment discards ‘const’ qualifier from pointer
    target type [-Wdiscarded-qualifiers]
      907 |       if ((r = strpbrk(name, "<=>")) != 0)
	  |              ^

    /home/test/libsolv/src/selection.c: In function ‘selection_canon’:
    /home/test/libsolv/src/selection.c:1175:14: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     1175 |       if ((r = strchr(name, '_')) == 0)
	  |              ^
    /home/test/libsolv/src/selection.c:1198:14: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     1198 |       if ((r = strchr(name, '-')) == 0)
	  |              ^
    /home/test/libsolv/src/selection.c:1219:10: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
     1219 |   if ((r = strrchr(name, '-')) == 0)
	  |          ^

    /home/test/libsolv/src/suse.c: In function ‘repo_fix_supplements’:
    /home/test/libsolv/src/suse.c:166:23: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      166 |           else if ((p = strchr(dep, ':')) != 0 && p != dep && p[1] == '/' && strlen(dep) < sizeof(buf))
	  |                       ^

    /home/test/libsolv/ext/solv_xfopen.c: In function ‘solv_xfopen’:
    /home/test/libsolv/ext/solv_xfopen.c:670:7: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      670 |   suf = strrchr(fn, '.');
	  |       ^
    /home/test/libsolv/ext/solv_xfopen.c: In function ‘solv_xfopen_fd’:
    /home/test/libsolv/ext/solv_xfopen.c:737:7: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      737 |   suf = fn ? strrchr(fn, '.') : 0;
	  |       ^

This patch fixes them.