### PR TITLE
Fix repo_unset clearing wrong field for SOLVABLE_SUPPLEMENTS

### DIFF
--- a/src/repo.c
+++ b/src/repo.c
@@ -1621,6 +1621,7 @@ repo_unset(Repo *repo, Id p, Id keyname)
 	  return;
 	case SOLVABLE_SUPPLEMENTS:
 	  s->supplements = 0;
+	  return;
 	case SOLVABLE_ENHANCES:
 	  s->enhances = 0;
 	  return;


### PR DESCRIPTION
## Summary

The case for `SOLVABLE_SUPPLEMENTS` in `repo_unset()` (`src/repo.c`) is missing a `return;` and falls through to the `SOLVABLE_ENHANCES` case. As a result, calling `repo_unset(repo, p, SOLVABLE_SUPPLEMENTS)` clears both `s->supplements` **and** `s->enhances`.

```c
case SOLVABLE_SUPPLEMENTS:
  s->supplements = 0;
  /* missing return; */
case SOLVABLE_ENHANCES:
  s->enhances = 0;
  return;
```

The bug has been present since the function (originally named `repo_set_deleted`) was introduced in 5f153e32 (Nov 2012). It surfaced when compiling with `-Wimplicit-fallthrough=5`.

## Test plan
- [ ] Confirm `repo_unset(repo, p, SOLVABLE_SUPPLEMENTS)` no longer touches `s->enhances`
- [ ] Existing test suite continues to pass