### PR TITLE
Fix const correctness with libxml2 >= 2.12.0

### DIFF
--- a/ext/solv_xmlparser.c
+++ b/ext/solv_xmlparser.c
@@ -291,7 +291,7 @@ parse_block(struct solv_xmlparser *xmlp, char *buf, int l)
     }
   if (xmlParseChunk(xmlp->parser, buf, l, l == 0 ? 1 : 0))
     {
-      xmlErrorPtr err = xmlCtxtGetLastError(xmlp->parser);
+      const xmlError *err = xmlCtxtGetLastError(xmlp->parser);
       set_error(xmlp, err->message, err->line, err->int2);
       return 0;
     }


### PR DESCRIPTION
If configured with -DENABLE_RPMMD=ON -DWITH_LIBXML2=ON and building with libxml2-2.13.9, this warning was reported:

    /home/test/libsolv/ext/solv_xmlparser.c:294:25: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      294 |       xmlErrorPtr err = xmlCtxtGetLastError(xmlp->parser);
	  |                         ^~~~~~~~~~~~~~~~~~~

The cause was that libxml2 2.12.0 changed a prototype of xmlCtxtGetLastError(). This patch fixes it.