### PR TITLE
Make file time available for dnf plugins

### DIFF
--- a/ext/repo_rpmmd.c
+++ b/ext/repo_rpmmd.c
@@ -849,6 +849,9 @@ startElement(struct solv_xmlparser *xmlp, int state, const char *name, const cha
         str = solv_xmlparser_find_attr("build", atts);
         if (str && (ti = strtoull(str, 0, 10)) != 0)
           repodata_set_num(pd->data, handle, SOLVABLE_BUILDTIME, ti);
+        str = solv_xmlparser_find_attr("file", atts);
+        if (str && (ti = strtoull(str, 0, 10)) != 0)
+          repodata_set_num(pd->data, handle, SOLVABLE_FILETIME, ti);
 	break;
       }
     case STATE_SIZE:

--- a/src/knownid.h
+++ b/src/knownid.h
@@ -274,6 +274,7 @@ KNOWNID(UPDATE_COLLECTIONLIST,		"update:collectionlist"),	/* list of UPDATE_COLL
 KNOWNID(SOLVABLE_MULTIARCH,		"solvable:multiarch"),		/* debian multi-arch field */
 KNOWNID(SOLVABLE_SIGNATUREDATA,		"solvable:signaturedata"),	/* conda */
 KNOWNID(SOLVABLE_ORDERWITHREQUIRES,	"solvable:orderwithrequires"),	/* rpm */
+KNOWNID(SOLVABLE_FILETIME,		"solvable:filetime"),		/* file publish time from rpm-md <time file="..."> */
 
 KNOWNID(ID_NUM_INTERNAL,		0)
 


### PR DESCRIPTION
Makes the "file" time for a given package available for plugin use, to enable virtual snapshots (safe upgrades) based on the time a file was published.